### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.frameworkadmin.test

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin.test/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/META-INF/MANIFEST.MF
@@ -4,11 +4,11 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.frameworkadmin.test
 Bundle-Version: 1.4.400.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.equinox.frameworkadmin,
- org.eclipse.equinox.frameworkadmin.equinox;bundle-version="1.0.100",
- org.junit;bundle-version="3.8.0",
- org.eclipse.equinox.simpleconfigurator.manipulator
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4)",
+ org.eclipse.equinox.frameworkadmin;bundle-version="[2.3.200,3)",
+ org.eclipse.equinox.frameworkadmin.equinox;bundle-version="[1.3.200,2)",
+ org.junit;bundle-version="[4.13.2,5)",
+ org.eclipse.equinox.simpleconfigurator.manipulator;bundle-version="[2.3.300,3)"
 Bundle-Activator: org.eclipse.equinox.frameworkadmin.tests.Activator
 Import-Package: org.osgi.framework;version="1.4.0"
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.