### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.console

### DIFF
--- a/bundles/org.eclipse.equinox.p2.console/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.console;singleton:=true
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.console.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -24,5 +24,5 @@ Import-Package: org.eclipse.equinox.internal.p2.core.helpers,
  org.osgi.framework;version="1.6.0",
  org.osgi.util.tracker;version="1.4.0"
 Bundle-ActivationPolicy: lazy
-Require-Bundle: org.eclipse.equinox.common;bundle-version="3.3.0"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4)"
 Automatic-Module-Name: org.eclipse.equinox.p2.console


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.