### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.directorywatcher

### DIFF
--- a/bundles/org.eclipse.equinox.p2.directorywatcher/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.directorywatcher/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.directorywatcher;singleton:=true
-Bundle-Version: 1.4.400.qualifier
+Bundle-Version: 1.4.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.provisional.p2.directorywatcher;x-friends:="org.eclipse.equinox.p2.reconciler.dropins,org.eclipse.equinox.p2.extensionlocation"
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.7.0,4.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.equinox.internal.p2.artifact.repository.simple,


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.