### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.discovery.compatibility

### DIFF
--- a/bundles/org.eclipse.equinox.p2.discovery.compatibility/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.discovery.compatibility/META-INF/MANIFEST.MF
@@ -5,11 +5,11 @@ Bundle-SymbolicName: org.eclipse.equinox.p2.discovery.compatibility;singleton:=t
 Bundle-Version: 1.3.400.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
- org.eclipse.equinox.p2.core;bundle-version="2.0.0",
- org.eclipse.equinox.p2.discovery;bundle-version="1.0.0",
- org.eclipse.equinox.p2.repository;bundle-version="2.1.0",
- org.eclipse.equinox.p2.transport.ecf;bundle-version="1.0.0"
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4)",
+ org.eclipse.equinox.p2.core;bundle-version="[2.12.100,3)",
+ org.eclipse.equinox.p2.discovery;bundle-version="[1.3.300,2)",
+ org.eclipse.equinox.p2.repository;bundle-version="[2.9.100,3)",
+ org.eclipse.equinox.p2.transport.ecf;bundle-version="[1.4.300,2)"
 Export-Package: org.eclipse.equinox.internal.p2.discovery.compatibility;x-friends:="org.eclipse.equinox.p2.ui.discovery",
  org.eclipse.equinox.internal.p2.discovery.compatibility.util;x-friends:="org.eclipse.equinox.p2.ui.discovery"
 Bundle-Localization: plugin


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.