### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.discovery

### DIFF
--- a/bundles/org.eclipse.equinox.p2.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.discovery/META-INF/MANIFEST.MF
@@ -2,11 +2,11 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.discovery;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.eclipse.core.runtime;bundle-version="3.29.0",
- org.eclipse.equinox.p2.core;bundle-version="2.0.0"
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4)",
+ org.eclipse.equinox.p2.core;bundle-version="[2.12.100,3)"
 Export-Package: org.eclipse.equinox.internal.p2.discovery;x-friends:="org.eclipse.equinox.p2.discovery.compatibility,org.eclipse.equinox.p2.ui.discovery,org.eclipse.equinox.p2.discovery.repository",
  org.eclipse.equinox.internal.p2.discovery.model;x-friends:="org.eclipse.equinox.p2.discovery.compatibility,org.eclipse.equinox.p2.ui.discovery,org.eclipse.equinox.p2.discovery.repository",
  org.eclipse.equinox.internal.p2.discovery.util;x-friends:="org.eclipse.equinox.p2.discovery.compatibility,org.eclipse.equinox.p2.ui.discovery,org.eclipse.equinox.p2.discovery.repository"


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.