### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.engine

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.engine/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.engine;singleton:=true
-Bundle-Version: 2.10.200.qualifier
+Bundle-Version: 2.10.300.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.engine.EngineActivator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -24,9 +24,9 @@ Export-Package: org.eclipse.equinox.internal.p2.engine;
  org.eclipse.equinox.p2.engine;version="2.3.0",
  org.eclipse.equinox.p2.engine.query;version="2.0.0",
  org.eclipse.equinox.p2.engine.spi;version="2.0.0"
-Require-Bundle: org.eclipse.equinox.common,
- org.eclipse.equinox.registry,
- org.eclipse.core.jobs;bundle-version="[3.4.0,4.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4)",
+ org.eclipse.equinox.registry;bundle-version="[3.12.100,4)",
+ org.eclipse.core.jobs;bundle-version="[3.15.400,4.0.0)"
 Eclipse-RegisterBuddy: org.eclipse.equinox.p2.metadata.repository
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.