### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.extensionlocation

### DIFF
--- a/bundles/org.eclipse.equinox.p2.extensionlocation/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.extensionlocation;singleton:=true
-Bundle-Version: 1.5.400.qualifier
+Bundle-Version: 1.5.500.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.extensionlocation.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.extensionlocation;x-friends:="org.eclipse.equinox.p2.reconciler.dropins,org.eclipse.equinox.p2.ui,org.eclipse.equinox.p2.ui.importexport"
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.equinox.p2.metadata;bundle-version="[2.8.0,3.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4.0.0)",
+ org.eclipse.equinox.p2.metadata;bundle-version="[2.9.100,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.equinox.internal.p2.artifact.repository.simple,


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.