### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.garbagecollector

### DIFF
--- a/bundles/org.eclipse.equinox.p2.garbagecollector/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.garbagecollector/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.garbagecollector;singleton:=true
-Bundle-Version: 1.3.300.qualifier
+Bundle-Version: 1.3.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.garbagecollector;x-friends:="org.eclipse.equinox.p2.touchpoint.eclipse,org.eclipse.pde.core,org.eclipse.equinox.p2.ui.sdk.scheduler"
-Require-Bundle: org.eclipse.equinox.p2.engine,
- org.eclipse.equinox.registry;bundle-version="[3.4.0,4.0.0)"
+Require-Bundle: org.eclipse.equinox.p2.engine;bundle-version="[2.10.200,3)",
+ org.eclipse.equinox.registry;bundle-version="[3.12.100,4.0.0)"
 Import-Package: org.eclipse.core.runtime.preferences,
  org.eclipse.equinox.app;version="1.0.0",
  org.eclipse.equinox.internal.p2.core.helpers,


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.