### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.jarprocessor

### DIFF
--- a/bundles/org.eclipse.equinox.p2.jarprocessor/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.jarprocessor/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.equinox.p2.jarprocessor;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 1.3.400.qualifier
+Bundle-Version: 1.3.500.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Main-Class: org.eclipse.equinox.internal.p2.jarprocessor.Main
 Export-Package: org.eclipse.equinox.internal.p2.jarprocessor;x-friends:="org.eclipse.equinox.p2.artifact.repository,org.eclipse.pde.build",
@@ -12,5 +12,5 @@ Export-Package: org.eclipse.equinox.internal.p2.jarprocessor;x-friends:="org.ecl
  org.eclipse.equinox.internal.p2.jarprocessor.verifier;x-internal:=true,
  org.eclipse.internal.provisional.equinox.p2.jarprocessor;x-friends:="org.eclipse.equinox.p2.artifact.optimizers,org.eclipse.equinox.p2.artifact.repository,org.eclipse.pde.build"
 Import-Package: org.eclipse.core.runtime.jobs;resolution:=optional
-Require-Bundle: org.eclipse.equinox.common;bundle-version="3.3.0"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4)"
 Automatic-Module-Name: org.eclipse.equinox.p2.jarprocessor


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.