### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.operations

### DIFF
--- a/bundles/org.eclipse.equinox.p2.operations/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.operations/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.operations;singleton:=true
-Bundle-Version: 2.7.400.qualifier
+Bundle-Version: 2.7.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.operations;x-friends:="org.eclipse.pde.ui,org.eclipse.equinox.p2.ui",
  org.eclipse.equinox.p2.operations;version="2.0.0"
-Require-Bundle: org.eclipse.equinox.common;bundle-version="3.6.0",
- org.eclipse.core.jobs;bundle-version="3.5.0"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4)",
+ org.eclipse.core.jobs;bundle-version="[3.15.400,4)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.equinox.internal.p2.core.helpers,


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.