### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.metadata

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.metadata/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.metadata;singleton:=true
-Bundle-Version: 2.9.100.qualifier
+Bundle-Version: 2.9.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.metadata;
@@ -79,8 +79,8 @@ Export-Package: org.eclipse.equinox.internal.p2.metadata;
  org.eclipse.equinox.p2.metadata.expression;version="2.0.0",
  org.eclipse.equinox.p2.metadata.index;version="2.0.0",
  org.eclipse.equinox.p2.query;version="2.1.0"
-Require-Bundle: org.eclipse.equinox.common,
- org.eclipse.equinox.p2.core;bundle-version="[2.0.0,3.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4)",
+ org.eclipse.equinox.p2.core;bundle-version="[2.12.100,3.0.0)"
 Import-Package: org.eclipse.osgi.service.localization;version="1.0.0",
  org.eclipse.osgi.util,
  org.osgi.framework;version="1.6.0"


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.