### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.publisher.eclipse

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/META-INF/MANIFEST.MF
@@ -59,5 +59,5 @@ Export-Package: org.eclipse.equinox.internal.p2.publisher.compatibility;x-intern
  org.eclipse.pde.internal.build.publisher;x-friends:="org.eclipse.pde.build",
  org.eclipse.pde.internal.publishing;x-friends:="org.eclipse.pde.build",
  org.eclipse.pde.internal.swt.tools;x-internal:=true
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4.0.0)"
 Automatic-Module-Name: org.eclipse.equinox.p2.publisher.eclipse


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.