### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.reconciler.dropins

### DIFF
--- a/bundles/org.eclipse.equinox.p2.reconciler.dropins/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.reconciler.dropins/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.reconciler.dropins;singleton:=true
-Bundle-Version: 1.5.400.qualifier
+Bundle-Version: 1.5.500.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.reconciler.dropins.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.internal.p2.reconciler.dropins;x-internal:=true
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)",
- org.eclipse.equinox.p2.touchpoint.eclipse;bundle-version="1.0.0",
- org.eclipse.equinox.p2.metadata
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4.0.0)",
+ org.eclipse.equinox.p2.touchpoint.eclipse;bundle-version="[2.4.300,3)",
+ org.eclipse.equinox.p2.metadata;bundle-version="[2.9.100,3)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.equinox.app;version="1.0.0",
  org.eclipse.equinox.internal.p2.artifact.repository,


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.