### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.tests.discovery

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests.discovery/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests.discovery/META-INF/MANIFEST.MF
@@ -2,19 +2,19 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests.discovery;singleton:=true
-Bundle-Version: 1.4.500.qualifier
+Bundle-Version: 1.4.600.qualifier
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Localization: plugin
 Export-Package: org.eclipse.equinox.p2.discovery.tests;x-internal:=true,
  org.eclipse.equinox.p2.discovery.tests.core;x-internal:=true,
  org.eclipse.equinox.p2.discovery.tests.core.mock;x-internal:=true,
  org.eclipse.equinox.p2.discovery.tests.core.util;x-internal:=true
-Require-Bundle: org.eclipse.equinox.p2.discovery;bundle-version="1.0.0",
- org.eclipse.equinox.p2.discovery.compatibility;bundle-version="1.0.0",
- org.eclipse.equinox.p2.ui.discovery;bundle-version="1.0.0",
- org.junit;bundle-version="3.8.0",
- org.eclipse.core.runtime;bundle-version="3.29.0",
- org.eclipse.ui;bundle-version="3.1.0"
+Require-Bundle: org.eclipse.equinox.p2.discovery;bundle-version="[1.3.300,2)",
+ org.eclipse.equinox.p2.discovery.compatibility;bundle-version="[1.3.400,2)",
+ org.eclipse.equinox.p2.ui.discovery;bundle-version="[1.3.400,2)",
+ org.junit;bundle-version="[4.13.2,5)",
+ org.eclipse.core.runtime;bundle-version="[3.31.100,4)",
+ org.eclipse.ui;bundle-version="[3.206.100,4)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.equinox.p2.tests.discovery


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.