### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.tests.verifier

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests.verifier/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.tests.verifier/META-INF/MANIFEST.MF
@@ -2,15 +2,15 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.equinox.p2.tests.verifier;singleton:=true
-Bundle-Version: 1.4.300.qualifier
+Bundle-Version: 1.4.400.qualifier
 Export-Package: org.eclipse.equinox.internal.p2.tests.verifier;x-internal:=true
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.equinox.p2.core,
- org.eclipse.equinox.p2.ui.sdk.scheduler;bundle-version="1.2.0",
- org.eclipse.swt;bundle-version="3.102.0",
- org.eclipse.equinox.p2.metadata;bundle-version="2.2.0",
- org.eclipse.equinox.p2.ui;bundle-version="2.3.0",
- org.eclipse.equinox.p2.operations;bundle-version="2.3.0"
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.100,4)",
+ org.eclipse.equinox.p2.core;bundle-version="[2.12.100,3)",
+ org.eclipse.equinox.p2.ui.sdk.scheduler;bundle-version="[1.6.300,2)",
+ org.eclipse.swt;bundle-version="[3.127.0,4)",
+ org.eclipse.equinox.p2.metadata;bundle-version="[2.9.100,3)",
+ org.eclipse.equinox.p2.ui;bundle-version="[2.8.500,3)",
+ org.eclipse.equinox.p2.operations;bundle-version="[2.7.400,3)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.eclipse.equinox.internal.p2.core.helpers,
  org.eclipse.equinox.internal.p2.engine,


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.