### PR TITLE
Bundle Dependencies Version Bumps for bundles/org.eclipse.equinox.p2.touchpoint.eclipse

### DIFF
--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.equinox.p2.touchpoint.eclipse;singleton:=true
-Bundle-Version: 2.4.300.qualifier
+Bundle-Version: 2.4.400.qualifier
 Bundle-Activator: org.eclipse.equinox.internal.p2.touchpoint.eclipse.Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -14,7 +14,7 @@ Export-Package: org.eclipse.equinox.internal.p2.touchpoint.eclipse;version="2.0.
  org.eclipse.equinox.internal.p2.touchpoint.eclipse.actions;version="2.0.0";x-internal:=true,
  org.eclipse.equinox.internal.p2.update;version="2.0.0";x-friends:="org.eclipse.equinox.p2.reconciler.dropins,org.eclipse.equinox.p2.extensionlocation,org.eclipse.equinox.p2.directorywatcher",
  org.eclipse.equinox.p2.touchpoint.eclipse.query;version="2.0.0"
-Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.18.0,4.0.0)"
+Require-Bundle: org.eclipse.equinox.common;bundle-version="[3.19.100,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.xml.parsers,


### PR DESCRIPTION
Please review the changes and merge if appropriate, or cherry pick individual updates.