### PR TITLE
Update version ranges of dependencies for bundles/org.eclipse.equinox.p2.touchpoint.natives

### DIFF
--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/META-INF/MANIFEST.MF
@@ -14,19 +14,18 @@ Require-Bundle:
  org.eclipse.equinox.app;bundle-version="1.3.0";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
-Import-Package: 
- org.eclipse.equinox.internal.p2.core.helpers,
+Import-Package: org.eclipse.equinox.internal.p2.core.helpers,
  org.eclipse.equinox.internal.p2.engine,
- org.eclipse.equinox.p2.core;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.core;version="[2.7.0,3)",
  org.eclipse.equinox.p2.engine;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.engine.spi;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.metadata;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.metadata.expression;version="2.0.0";resolution:=optional,
  org.eclipse.equinox.p2.query;version="2.0.0";resolution:=optional,
  org.eclipse.equinox.p2.repository;version="[2.0.0,3.0.0)",
- org.eclipse.equinox.p2.repository.artifact;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.repository.artifact;version="[2.1.0,3)",
  org.eclipse.osgi.service.environment;version="1.3.0",
  org.eclipse.osgi.util;version="1.0.0",
- org.osgi.framework;version="1.3.0",
+ org.osgi.framework;version="[1.6.0,2)",
  org.osgi.service.packageadmin;version="1.2.0"
 Automatic-Module-Name: org.eclipse.equinox.p2.touchpoint.natives


### PR DESCRIPTION
Import-Package `org.eclipse.equinox.p2.core [2.0.0,3.0.0)` (compiled against `2.13.0` provided by `org.eclipse.equinox.p2.core 2.13.0.v20250115-0707`) includes `2.0.0` (provided by `org.eclipse.equinox.p2.core 2.4.0.v20150527-1706`) but this version is missing the method `org/eclipse/equinox/p2/core/IProvisioningAgent#getService` referenced by `org.eclipse.equinox.internal.p2.touchpoint.natives.NativePackageExtractionApplication` and 2 other.

Import-Package `org.eclipse.equinox.p2.repository.artifact [2.0.0,3.0.0)` (compiled against `2.3.0` provided by `org.eclipse.equinox.p2.repository 2.9.300.v20241213-1505`) includes `2.0.0` (provided by `org.eclipse.equinox.p2.repository 2.1.0.v20110601`) but this version is missing the method `org/eclipse/equinox/p2/repository/artifact/IArtifactRepositoryManager#createMirrorRequest` referenced by `org.eclipse.equinox.internal.p2.touchpoint.natives.actions.CollectAction`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/BundleContext#getServiceReference` referenced by `org.eclipse.equinox.internal.p2.touchpoint.natives.NativePackageExtractionApplication` and 1 other.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/Version#compareTo` referenced by `org.eclipse.equinox.internal.p2.touchpoint.natives.actions.BlockMacUpdate`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/Bundle#getVersion` referenced by `org.eclipse.equinox.internal.p2.touchpoint.natives.actions.BlockMacUpdate`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/BundleContext#getServiceReference` referenced by `org.eclipse.equinox.internal.p2.touchpoint.natives.NativePackageExtractionApplication` and 1 other.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/Version#compareTo` referenced by `org.eclipse.equinox.internal.p2.touchpoint.natives.actions.BlockMacUpdate`.


Suggested lower version for package `org.osgi.framework` is `1.6.0` out of [`1.4.0`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`, `1.9.0`, `1.10.0`]
Suggested lower version for package `org.eclipse.equinox.p2.core` is `2.7.0` out of [`2.0.0`, `2.7.0`, `2.8.0`, `2.12.0`, `2.13.0`]
Suggested lower version for package `org.eclipse.equinox.p2.repository.artifact` is `2.1.0` out of [`2.0.0`, `2.1.0`, `2.3.0`]