### PR TITLE
Update version ranges of dependencies for bundles/org.eclipse.equinox.p2.updatechecker

### DIFF
--- a/bundles/org.eclipse.equinox.p2.updatechecker/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.p2.updatechecker/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Service-Component: OSGI-INF/updatechecker.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.equinox.internal.p2.core.helpers,
- org.eclipse.equinox.p2.core;version="[2.0.0,3.0.0)",
+ org.eclipse.equinox.p2.core;version="[2.7.0,3)",
  org.eclipse.equinox.p2.core.spi;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.engine;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.p2.metadata;version="[2.0.0,3.0.0)",


### PR DESCRIPTION
Import-Package `org.eclipse.equinox.p2.core [2.0.0,3.0.0)` (compiled against `2.13.0` provided by `org.eclipse.equinox.p2.core 2.13.0.v20250115-0707`) includes `2.0.0` (provided by `org.eclipse.equinox.p2.core 2.4.0.v20150527-1706`) but this version is missing the method `org/eclipse/equinox/p2/core/IProvisioningAgent#getService` referenced by `org.eclipse.equinox.internal.p2.updatechecker.UpdateChecker`.


Suggested lower version for package `org.eclipse.equinox.p2.core` is `2.7.0` out of [`2.0.0`, `2.7.0`, `2.8.0`, `2.12.0`, `2.13.0`]