### PR TITLE
Update version ranges of dependencies for bundles/org.eclipse.equinox.simpleconfigurator.manipulator

### DIFF
--- a/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.simpleconfigurator.manipulator/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Import-Package: org.eclipse.equinox.frameworkadmin;version="[2.0.0,3.0.0)",
  org.eclipse.equinox.internal.provisional.frameworkadmin,
  org.eclipse.equinox.internal.simpleconfigurator,
  org.eclipse.equinox.internal.simpleconfigurator.utils,
- org.osgi.framework;version="1.3.0"
+ org.osgi.framework;version="[1.6.0,2)"
 Bundle-Vendor: %providerName
 Export-Package: org.eclipse.equinox.internal.simpleconfigurator.manipulator;x-friends:="org.eclipse.equinox.p2.touchpoint.eclipse",
  org.eclipse.equinox.simpleconfigurator.manipulator;version="2.0.0"


### PR DESCRIPTION
Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/Version#compareTo` referenced by `org.eclipse.equinox.internal.simpleconfigurator.manipulator.SimpleConfiguratorManipulatorUtils`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/Version#compareTo` referenced by `org.eclipse.equinox.internal.simpleconfigurator.manipulator.SimpleConfiguratorManipulatorUtils`.


Suggested lower version for package `org.osgi.framework` is `1.6.0` out of [`1.4.0`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`, `1.9.0`, `1.10.0`]