### PR TITLE
Update version ranges of dependencies for bundles/org.eclipse.equinox.simpleconfigurator

### DIFF
--- a/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.equinox.simpleconfigurator/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.osgi.framework.console;version="1.0.0";resolution:=optional,
  org.eclipse.osgi.report.resolution;version="[1.0.0,2.0.0)",
  org.eclipse.osgi.service.datalocation;version="1.0.0";resolution:=optional,
- org.osgi.framework;version="1.3.0",
+ org.osgi.framework;version="[1.6.0,2)",
  org.osgi.framework.hooks.resolver;version="[1.0.0,2.0.0)",
  org.osgi.framework.namespace;version="1.0.0",
  org.osgi.framework.startlevel;version="1.0.0",


### PR DESCRIPTION
Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/Bundle#adapt` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/BundleContext#getBundle` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/BundleContext#getServiceReference` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.5.0` (provided by `org.eclipse.osgi 3.5.1.R35x_v20090827`) but this version is missing the method `org/osgi/framework/BundleContext#registerService` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/Bundle#adapt` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/Bundle#getVersion` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/BundleContext#getBundle` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/BundleContext#getServiceReference` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.

Import-Package `org.osgi.framework 1.3.0` (compiled against `1.10.0` provided by `org.eclipse.osgi 3.23.0.v20241212-0858`) includes `1.4.0` (provided by `org.eclipse.osgi 3.4.3.R34x_v20081215-1030`) but this version is missing the method `org/osgi/framework/BundleContext#registerService` referenced by `org.eclipse.equinox.internal.simpleconfigurator.ConfigApplier`.


Suggested lower version for package `org.osgi.framework` is `1.6.0` out of [`1.4.0`, `1.5.0`, `1.6.0`, `1.7.0`, `1.8.0`, `1.9.0`, `1.10.0`]