### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.core

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/OrderedProperties.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/OrderedProperties.java
@@ -177,7 +177,7 @@ public class OrderedProperties extends Dictionary<String, String> implements Map
 		return sb.toString();
 	}
 
-	private class StringsEnum implements Enumeration<String> {
+	private static class StringsEnum implements Enumeration<String> {
 
 		private final Iterator<String> iterator;
 


### PR DESCRIPTION
The following cleanups where applied:
- Make inner classes static where possibleThe following warnings has been resolved:
- Empty block should be documented in /org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/provisional/p2/core/eventbus/SynchronousProvisioningListener.java at line 16
- StrongPool<T> implements non-API interface IPool<T> in /org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/StrongPool.java at line 29
- WeakPool<T> implements non-API interface IPool<T> in /org.eclipse.equinox.p2.core/src/org/eclipse/equinox/p2/core/WeakPool.java at line 29