### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.discovery.compatibility

### DIFF
--- a/bundles/org.eclipse.equinox.p2.discovery.compatibility/src/org/eclipse/equinox/internal/p2/discovery/compatibility/DirectoryParser.java
+++ b/bundles/org.eclipse.equinox.p2.discovery.compatibility/src/org/eclipse/equinox/internal/p2/discovery/compatibility/DirectoryParser.java
@@ -64,7 +64,7 @@ public class DirectoryParser {
 		return contentHandler.directory;
 	}
 
-	private class DirectoryContentHandler implements ContentHandler {
+	private static class DirectoryContentHandler implements ContentHandler {
 
 		Directory directory;
 


### PR DESCRIPTION
The following cleanups where applied:
- Make inner classes static where possible