### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.metadata

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Pipe.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Pipe.java
@@ -24,7 +24,7 @@ import org.eclipse.equinox.p2.metadata.index.IIndexProvider;
 
 public class Pipe extends NAry {
 
-	private class NoIndexProvider implements IIndexProvider<Object> {
+	private static class NoIndexProvider implements IIndexProvider<Object> {
 		private final IIndexProvider<?> indexProvider;
 		private Everything<Object> everything;
 


### PR DESCRIPTION
The following cleanups where applied:
- Make inner classes static where possibleThe following warnings has been resolved:
- The type IMatchQuery<?> is deprecated in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/WrappedIQuery.java at line 75
- The type IMatchQuery<?> is deprecated in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/WrappedIQuery.java at line 44
- The type IMatchQuery<Object> is deprecated in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/WrappedIQuery.java at line 50
- The method isMatch(Object) from the type IMatchQuery<Object> is deprecated in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/WrappedIQuery.java at line 50
- ExpressionParser implements non-API interface IExpressionConstants in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/parser/ExpressionParser.java at line 21
- IContextExpression<T> implements non-API interface IExpression in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/expression/IContextExpression.java at line 24
- IFilterExpression leaks APIs from the superinterface IExpression in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/expression/IFilterExpression.java at line 24
- IMatchExpression<T> implements non-API interface IExpression in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/expression/IMatchExpression.java at line 26
- IQueryWithIndex<T> implements non-API interface IQuery<T> in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/index/IQueryWithIndex.java at line 23
- The method ExpressionMatchQuery<T>.isMatch(T) overrides a deprecated method from IMatchQuery<T> in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/ExpressionMatchQuery.java at line 99
- ExpressionMatchQuery<T> implements non-API interface IMatchQuery<T> in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/ExpressionMatchQuery.java at line 36
- The type IMatchQuery<T> is deprecated in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/ExpressionMatchQuery.java at line 36
- The type IMatchQuery<?> is deprecated in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/ExpressionQuery.java at line 80
- MatchQuery<T> implements non-API interface IMatchQuery<T> in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/MatchQuery.java at line 44
- The type IMatchQuery<?> is deprecated in /org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/QueryUtil.java at line 116