### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.publisher.eclipse

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/BundleDescriptionImpl.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/BundleDescriptionImpl.java
@@ -459,7 +459,7 @@ final class BundleDescriptionImpl extends BaseDescriptionImpl implements BundleD
 			lazyData = new LazyData();
 	}
 
-	final class LazyData {
+	static final class LazyData {
 		String location;
 		String platformFilter;
 


### PR DESCRIPTION
The following cleanups where applied:
- Make inner classes static where possibleThe following warnings has been resolved:
- The method toURL() from the type File is deprecated in /org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/DataLoader.java at line 107
- The method loadManifestIgnoringExceptions(File) from the type BundlesAction is deprecated in /org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/ConfigCUsAction.java at line 162
- The method basicLoadManifestIgnoringExceptions(File) from the type BundlesAction is deprecated in /org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/build/publisher/GatherBundleAction.java at line 53