### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.ui.discovery

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/GradientCanvas.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/GradientCanvas.java
@@ -55,7 +55,7 @@ public class GradientCanvas extends Canvas {
 
 	private GradientInfo gradientInfo;
 
-	private class GradientInfo {
+	private static class GradientInfo {
 		Color[] gradientColors;
 
 		int[] percents;


### PR DESCRIPTION
The following cleanups where applied:
- Make inner classes static where possibleThe following warnings has been resolved:
- DiscoveryInstallOperation illegally references constructor RemediationOperation(ProvisioningSession, IProfileChangeRequest) in /org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/operations/DiscoveryInstallOperation.java at line 83
- DiscoveryInstallOperation illegally references method ProfileChangeOperation.resolveModal(IProgressMonitor) in /org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/operations/DiscoveryInstallOperation.java at line 85
- Unnecessary @SuppressWarnings("restriction") in /org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/PatternFilter.java at line 33