### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.engine

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/TouchpointManager.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/TouchpointManager.java
@@ -30,7 +30,7 @@ public class TouchpointManager implements IRegistryChangeListener {
 	private static final String ATTRIBUTE_TYPE = "type"; //$NON-NLS-1$
 	private static final String ATTRIBUTE_VERSION = "version"; //$NON-NLS-1$
 
-	private class TouchpointEntry {
+	private static class TouchpointEntry {
 
 		private IConfigurationElement element;
 		private boolean createdExtension = false;


### PR DESCRIPTION
The following cleanups where applied:
- Make inner classes static where possible