### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.metadata

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Pipe.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Pipe.java
@@ -24,7 +24,7 @@ import org.eclipse.equinox.p2.metadata.index.IIndexProvider;
 
 public class Pipe extends NAry {
 
-	private class NoIndexProvider implements IIndexProvider<Object> {
+	private static class NoIndexProvider implements IIndexProvider<Object> {
 		private final IIndexProvider<?> indexProvider;
 		private Everything<Object> everything;
 


### PR DESCRIPTION
The following cleanups where applied:
- Make inner classes static where possible