### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.tests

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/ArtifactRepositoryMissingSizeData.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/ArtifactRepositoryMissingSizeData.java
@@ -102,7 +102,7 @@ public class ArtifactRepositoryMissingSizeData extends AbstractProvisioningTest 
 		}
 	}
 
-	private class SPhaseSet extends PhaseSet {
+	private static class SPhaseSet extends PhaseSet {
 		public SPhaseSet(Phase set) {
 			super(new Phase[] {set});
 		}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/director/DirectorApplicationTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/director/DirectorApplicationTest.java
@@ -751,7 +751,7 @@ public class DirectorApplicationTest extends AbstractProvisioningTest {
 		delete(destinationRepo);
 	}
 
-	private final class DummyCertificate extends Certificate {
+	private static final class DummyCertificate extends Certificate {
 		private final String identity;
 
 		DummyCertificate(String identity) {


### PR DESCRIPTION
The following cleanups where applied:
- Make inner classes static where possible