### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.core

### DIFF
--- a/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/OrderedProperties.java
+++ b/bundles/org.eclipse.equinox.p2.core/src/org/eclipse/equinox/internal/p2/core/helpers/OrderedProperties.java
@@ -177,7 +177,7 @@ public class OrderedProperties extends Dictionary<String, String> implements Map
 		return sb.toString();
 	}
 
-	private class StringsEnum implements Enumeration<String> {
+	private static class StringsEnum implements Enumeration<String> {
 
 		private final Iterator<String> iterator;
 


### PR DESCRIPTION
### The following cleanups where applied:

- Add missing '@Deprecated' annotations
- Add missing '@Override' annotations
- Add missing '@Override' annotations to implementations of interface methods
- Make inner classes static where possible

