### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.publisher.eclipse

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/BundleDescriptionImpl.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/BundleDescriptionImpl.java
@@ -459,7 +459,7 @@ final class BundleDescriptionImpl extends BaseDescriptionImpl implements BundleD
 			lazyData = new LazyData();
 	}
 
-	final class LazyData {
+	static final class LazyData {
 		String location;
 		String platformFilter;
 


### PR DESCRIPTION
### The following cleanups where applied:

- Add missing '@Deprecated' annotations
- Add missing '@Override' annotations
- Add missing '@Override' annotations to implementations of interface methods
- Make inner classes static where possible

