### PR TITLE
Clean Code for bundles/org.eclipse.equinox.frameworkadmin.test

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/AbstractFwkAdminTest.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/AbstractFwkAdminTest.java
@@ -61,8 +61,9 @@ public abstract class AbstractFwkAdminTest {
 	}
 
 	public static boolean delete(File file) {
-		if (!file.exists())
+		if (!file.exists()) {
 			return true;
+		}
 		if (file.isDirectory()) {
 			File[] children = file.listFiles();
 			for (File child : children) {
@@ -80,8 +81,9 @@ public abstract class AbstractFwkAdminTest {
 
 		String FWK_ADMIN_EQ = "org.eclipse.equinox.frameworkadmin.equinox";
 		Bundle b = Platform.getBundle(FWK_ADMIN_EQ);
-		if (b == null)
+		if (b == null) {
 			throw new IllegalStateException("Bundle: " + FWK_ADMIN_EQ + " is required for this test");
+		}
 		b.start();
 
 		if (fwAdminTracker == null) {
@@ -111,8 +113,9 @@ public abstract class AbstractFwkAdminTest {
 			testFolder = new File(url.getFile(), name);
 		}
 
-		if (clean && testFolder.exists())
+		if (clean && testFolder.exists()) {
 			delete(testFolder);
+		}
 		testFolder.mkdirs();
 		return testFolder;
 	}
@@ -138,8 +141,9 @@ public abstract class AbstractFwkAdminTest {
 	}
 
 	public void assertNotContent(String message, File file, String search) {
-		if (!file.exists())
+		if (!file.exists()) {
 			fail("File: " + file.toString() + " can't be found.");
+		}
 		try {
 			String failure = null;
 			StringBuilder fileContent = new StringBuilder();
@@ -177,22 +181,26 @@ public abstract class AbstractFwkAdminTest {
 
 	public void assertPropertyContains(File file, String property, String text) {
 		String value = getProperty(file, property);
-		if (value == null)
+		if (value == null) {
 			fail("property: " + property + " not found in: " +file);
+		}
 
 		int index = value.indexOf(text);
-		if (index == -1)
+		if (index == -1) {
 			fail(text + " not found in property:" + property + " for file: " +file);
+		}
 	}
 
 	public void assertNotPropertyContains(File file, String property, String text) {
 		String value = getProperty(file, property);
-		if (value == null)
+		if (value == null) {
 			return;
+		}
 
 		int index = value.indexOf(text);
-		if (index != -1)
+		if (index != -1) {
 			fail(text + " found in property:" + property + " for file: " +file);
+		}
 	}
 
 	public void assertContent(File file, String... search) {
@@ -200,8 +208,9 @@ public abstract class AbstractFwkAdminTest {
 	}
 
 	public void assertContent(String message, File file, String... lines) {
-		if (!file.exists())
+		if (!file.exists()) {
 			fail("File: " + file.toString() + " can't be found.");
+		}
 		int idx = 0;
 		StringBuilder fileContent = new StringBuilder();
 		try {
@@ -210,8 +219,9 @@ public abstract class AbstractFwkAdminTest {
 					String line = reader.readLine();
 					fileContent.append(line).append('\n');
 					if (line.indexOf(lines[idx]) >= 0) {
-						if(++idx >= lines.length)
+						if(++idx >= lines.length) {
 							return;
+						}
 					}
 				}
 			}
@@ -226,8 +236,9 @@ public abstract class AbstractFwkAdminTest {
 	public void startSimpleConfiguratorManipulator() {
 		final String SIMPLECONFIGURATOR_MANIPULATOR = "org.eclipse.equinox.simpleconfigurator.manipulator";
 		Bundle manipulatorBundle = Platform.getBundle(SIMPLECONFIGURATOR_MANIPULATOR);
-		if (manipulatorBundle == null)
+		if (manipulatorBundle == null) {
 			fail("Bundle: " + SIMPLECONFIGURATOR_MANIPULATOR + " is required for this test");
+		}
 		try {
 			manipulatorBundle.start();
 		} catch (BundleException e) {
@@ -241,14 +252,17 @@ public abstract class AbstractFwkAdminTest {
 	 * - if we have a directory then merge
 	 */
 	public static void copy(String message, File source, File target) {
-		if (!source.exists())
+		if (!source.exists()) {
 			return;
+		}
 		target.getParentFile().mkdirs();
 		if (source.isDirectory()) {
-			if (target.exists() && target.isFile())
+			if (target.exists() && target.isFile()) {
 				target.delete();
-			if (!target.exists())
+			}
+			if (!target.exists()) {
 				target.mkdirs();
+			}
 			File[] children = source.listFiles();
 			for (File child : children) {
 				copy(message, child, new File(target, child.getName()));
@@ -260,8 +274,9 @@ public abstract class AbstractFwkAdminTest {
 
 			byte[] buffer = new byte[8192];
 			int bytesRead = 0;
-			while ((bytesRead = input.read(buffer)) != -1)
+			while ((bytesRead = input.read(buffer)) != -1) {
 				output.write(buffer, 0, bytesRead);
+			}
 		} catch (IOException e) {
 			fail(message + ": " + e);
 		}
@@ -271,16 +286,19 @@ public abstract class AbstractFwkAdminTest {
 	 * Look up and return a file handle to the given entry in the bundle.
 	 */
 	protected File getTestData(String message, String entry) {
-		if (entry == null)
+		if (entry == null) {
 			fail(message + " entry is null.");
+		}
 		URL base = Activator.getContext().getBundle().getEntry(entry);
-		if (base == null)
+		if (base == null) {
 			fail(message + " entry not found in bundle: " + entry);
+		}
 		try {
 			String osPath = IPath.fromOSString(FileLocator.toFileURL(base).getPath()).toOSString();
 			File result = new File(osPath);
-			if (!result.getCanonicalPath().equals(result.getPath()))
+			if (!result.getCanonicalPath().equals(result.getPath())) {
 				fail(message + " result path: " + result.getPath() + " does not match canonical path: " + result.getCanonicalFile().getPath());
+			}
 			return result;
 		} catch (IOException e) {
 			fail(message + ": " + e);

--- a/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/FwkAdminAndSimpleConfiguratorTest.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/FwkAdminAndSimpleConfiguratorTest.java
@@ -91,8 +91,9 @@ public abstract class FwkAdminAndSimpleConfiguratorTest extends AbstractFwkAdmin
 	@After
 	public void tearDown() throws Exception {
 		super.tearDown();
-		if (installFolder != null)
+		if (installFolder != null) {
 			delete(installFolder);
+		}
 	}
 
 	public File getInstallFolder() {

--- a/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/LauncherConfigLocationTest.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/LauncherConfigLocationTest.java
@@ -34,8 +34,9 @@ public class LauncherConfigLocationTest extends AbstractFwkAdminTest {
 		Manipulator manipulator = fwkAdmin.getManipulator();
 
 		File installFolder = Activator.getContext().getDataFile(LauncherConfigLocationTest.class.getName());
-		if(installFolder.exists())
+		if(installFolder.exists()) {
 			delete(installFolder);
+		}
 
 		File configurationFolder = new File(installFolder, "configuration");
 		String launcherName = "foo";

--- a/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/RelativePathTest.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/RelativePathTest.java
@@ -100,22 +100,25 @@ public class RelativePathTest extends FwkAdminAndSimpleConfiguratorTest {
 
 	@Test
 	public void testMakeRelative_NonWindows() throws MalformedURLException {
-		if (WINDOWS)
+		if (WINDOWS) {
 			return;
+		}
 		URL base = new URL("file:/eclipse/");
 		// data - [0] is the test data and [1] is the expected result
 		String[][] data = new String[][] { //
 				new String[] { "file:/home/eclipse/foo.jar", "file:../home/eclipse/foo.jar" }, //
 				new String[] { "file:///home/eclipse/foo.jar", "file:../home/eclipse/foo.jar" }, //
 		};
-		for (int i = 0; i < data.length; i++)
+		for (int i = 0; i < data.length; i++) {
 			assertEquals("1." + i, data[i][1], EquinoxManipulatorImpl.makeRelative(data[i][0], base));
+		}
 	}
 
 	@Test
 	public void testMakeRelative_Windows() throws MalformedURLException {
-		if (!WINDOWS)
+		if (!WINDOWS) {
 			return;
+		}
 		// platform specific data
 		URL base = new URL("file:/c:/a/eclipse/");
 		// data - [0] is the test data and [1] is the expected result
@@ -128,7 +131,8 @@ public class RelativePathTest extends FwkAdminAndSimpleConfiguratorTest {
 				new String[] { "file:/d:/a/eclipse/plugins/bar.jar", "file:/d:/a/eclipse/plugins/bar.jar" }, //
 				new String[] { "file:/c:/x/eclipse/plugins/bar.jar", "file:../../x/eclipse/plugins/bar.jar" }, //
 		};
-		for (int i = 0; i < data.length; i++)
+		for (int i = 0; i < data.length; i++) {
 			assertEquals("2." + i, data[i][1], EquinoxManipulatorImpl.makeRelative(data[i][0], base));
+		}
 	}
 }

--- a/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/TestRunningInstance.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin.test/src/org/eclipse/equinox/frameworkadmin/tests/TestRunningInstance.java
@@ -28,8 +28,9 @@ public class TestRunningInstance extends AbstractFwkAdminTest {
 	@Test
 	public void testRunningInstance() throws BundleException {
 		// TODO Commented out due to NPE failure on Windows on test machines only
-		if (Platform.OS_WIN32.equals(Platform.getOS()))
+		if (Platform.OS_WIN32.equals(Platform.getOS())) {
 			return;
+		}
 		FrameworkAdmin fwkAdmin = getEquinoxFrameworkAdmin();
 		Manipulator m = fwkAdmin.getRunningManipulator();
 		BundleInfo[] infos = m.getConfigData().getBundles();
@@ -50,8 +51,9 @@ public class TestRunningInstance extends AbstractFwkAdminTest {
 
 	private boolean same(BundleInfo info, Bundle bundle) {
 		if (info.getSymbolicName().equals(bundle.getSymbolicName())) {
-			if (new Version(bundle.getHeaders().get(Constants.BUNDLE_VERSION)).equals(new Version(info.getVersion())))
+			if (new Version(bundle.getHeaders().get(Constants.BUNDLE_VERSION)).equals(new Version(info.getVersion()))) {
 				return true;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

