### PR TITLE
Clean Code for bundles/org.eclipse.equinox.frameworkadmin

### DIFF
--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/frameworkadmin/BundleInfo.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/frameworkadmin/BundleInfo.java
@@ -159,8 +159,9 @@ public class BundleInfo {
 	 * @return an {@link Version} string, or "0.0.0" if not set
 	 */
 	public String getVersion() {
-		if (version == null)
+		if (version == null) {
 			return EMPTY_VERSION;
+		}
 		return version;
 	}
 
@@ -280,10 +281,11 @@ public class BundleInfo {
 	 *            The version. A valid {@link Version} string.
 	 */
 	public void setVersion(String value) {
-		if (value == null)
+		if (value == null) {
 			this.version = EMPTY_VERSION;
-		else
+		} else {
 			this.version = value;
+		}
 	}
 
 	/**
@@ -300,8 +302,9 @@ public class BundleInfo {
 	public String toString() {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append("BundleInfo("); //$NON-NLS-1$
-		if (symbolicName != null)
+		if (symbolicName != null) {
 			buffer.append(symbolicName);
+		}
 		buffer.append(", "); //$NON-NLS-1$
 		buffer.append(version);
 
@@ -341,40 +344,49 @@ public class BundleInfo {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
+		}
 
-		if (obj == null)
+		if (obj == null) {
 			return false;
+		}
 
-		if (getClass() != obj.getClass())
+		if (getClass() != obj.getClass()) {
 			return false;
+		}
 
 		BundleInfo other = (BundleInfo) obj;
 		if (symbolicName == null) {
-			if (other.symbolicName != null)
+			if (other.symbolicName != null) {
 				return false;
-		} else if (!symbolicName.equals(other.symbolicName))
+			}
+		} else if (!symbolicName.equals(other.symbolicName)) {
 			return false;
+		}
 
-		if (!version.equals(other.getVersion()))
+		if (!version.equals(other.getVersion())) {
 			return false;
+		}
 
-		if (location == null || other.location == null)
+		if (location == null || other.location == null) {
 			return true;
+		}
 
 		// compare absolute location URIs
 		URI absoluteLocation = null;
-		if (location.isAbsolute() || baseLocation == null)
+		if (location.isAbsolute() || baseLocation == null) {
 			absoluteLocation = location;
-		else
+		} else {
 			absoluteLocation = URIUtil.append(baseLocation, URIUtil.toUnencodedString(location));
+		}
 
 		URI otherAbsoluteLocation = null;
-		if (other.location.isAbsolute() || other.baseLocation == null)
+		if (other.location.isAbsolute() || other.baseLocation == null) {
 			otherAbsoluteLocation = other.location;
-		else
+		} else {
 			otherAbsoluteLocation = URIUtil.append(other.baseLocation, URIUtil.toUnencodedString(other.location));
+		}
 		return URIUtil.sameURI(absoluteLocation, otherAbsoluteLocation);
 	}
 }

--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/frameworkadmin/utils/SimpleBundlesState.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/frameworkadmin/utils/SimpleBundlesState.java
@@ -33,9 +33,10 @@ public class SimpleBundlesState implements BundlesState {
 	 * Check if the specified FrameworkAdmin is available.
 	 */
 	public static void checkAvailability(FrameworkAdmin fwAdmin) throws FrameworkAdminRuntimeException {
-		if (!fwAdmin.isActive())
+		if (!fwAdmin.isActive()) {
 			throw new FrameworkAdminRuntimeException("FrameworkAdmin creates this object is no more available.", //$NON-NLS-1$
 					FrameworkAdminRuntimeException.FRAMEWORKADMIN_UNAVAILABLE);
+		}
 	}
 
 	/**
@@ -43,8 +44,9 @@ public class SimpleBundlesState implements BundlesState {
 	 * @return File of fwJar to be used.
 	 */
 	static File getFwJar(LauncherData launcherData) {
-		if (launcherData.getFwJar() != null)
+		if (launcherData.getFwJar() != null) {
 			return launcherData.getFwJar();
+		}
 		return null;
 	}
 
@@ -100,9 +102,10 @@ public class SimpleBundlesState implements BundlesState {
 
 	@Override
 	public BundleInfo[] getExpectedState() throws FrameworkAdminRuntimeException {
-		if (!fwAdmin.isActive())
+		if (!fwAdmin.isActive()) {
 			throw new FrameworkAdminRuntimeException("FrameworkAdmin creates this object is no more available.", //$NON-NLS-1$
 					FrameworkAdminRuntimeException.FRAMEWORKADMIN_UNAVAILABLE);
+		}
 		return Utils.getBundleInfosFromList(this.bundleInfosList);
 	}
 
@@ -117,13 +120,15 @@ public class SimpleBundlesState implements BundlesState {
 	public BundleInfo[] getPrerequisteBundles(BundleInfo bInfo) {
 		URI location = bInfo.getLocation();
 		final String requiredBundles = Utils.getManifestMainAttributes(location, Constants.REQUIRE_BUNDLE);
-		if (requiredBundles == null)
+		if (requiredBundles == null) {
 			return new BundleInfo[] { this.getSystemBundle() };
+		}
 
 		String[] clauses = Utils.getClauses(requiredBundles);
 		List<String> list = new LinkedList<>();
-		for (String clause : clauses)
+		for (String clause : clauses) {
 			list.add(Utils.getPathFromClause(clause));
+		}
 
 		List<BundleInfo> ret = new LinkedList<>();
 		ret.add(this.getSystemBundle());
@@ -131,8 +136,9 @@ public class SimpleBundlesState implements BundlesState {
 			URI currentLocation = currentBInfo.getLocation();
 			String currentSymbolicName = Utils.getManifestMainAttributes(currentLocation,
 					Constants.BUNDLE_SYMBOLICNAME);
-			if (currentSymbolicName == null)
+			if (currentSymbolicName == null) {
 				continue;
+			}
 			currentSymbolicName = Utils.getPathFromClause(currentSymbolicName);
 			for (String symbolicName : list) {
 				if (symbolicName.equals(currentSymbolicName)) {
@@ -154,8 +160,9 @@ public class SimpleBundlesState implements BundlesState {
 				String bundleName = Utils.getManifestMainAttributes(location, Constants.BUNDLE_NAME);
 				if (systemBundleName.equals(bundleName)) {
 					String bundleVendor = Utils.getManifestMainAttributes(location, Constants.BUNDLE_VENDOR);
-					if (systemBundleVendor.equals(bundleVendor))
+					if (systemBundleVendor.equals(bundleVendor)) {
 						return bInfo;
+					}
 				}
 			}
 			return null;
@@ -164,8 +171,9 @@ public class SimpleBundlesState implements BundlesState {
 			URI location = bInfo.getLocation();
 			String symbolicName = Utils.getManifestMainAttributes(location, Constants.BUNDLE_SYMBOLICNAME);
 			symbolicName = Utils.getPathFromClause(symbolicName);
-			if (this.systemBundleSymbolicName.equals(symbolicName))
+			if (this.systemBundleSymbolicName.equals(symbolicName)) {
 				return bInfo;
+			}
 		}
 		return null;
 	}
@@ -174,33 +182,39 @@ public class SimpleBundlesState implements BundlesState {
 	@SuppressWarnings("unchecked")
 	public BundleInfo[] getSystemFragmentedBundles() {
 		BundleInfo systemBInfo = this.getSystemBundle();
-		if (systemBInfo == null)
+		if (systemBInfo == null) {
 			return NULL_BUNDLEINFOS;
+		}
 
 		@SuppressWarnings("rawtypes")
 		List list = new LinkedList();
 		for (BundleInfo bInfo : this.bundleInfosList) {
 			URI location = bInfo.getLocation();
 			String manifestVersion = Utils.getManifestMainAttributes(location, Constants.BUNDLE_MANIFESTVERSION);
-			if (manifestVersion == null)
+			if (manifestVersion == null) {
 				continue;
-			if (manifestVersion.equals("1") || manifestVersion.equals("1.0")) //$NON-NLS-1$//$NON-NLS-2$
+			}
+			if (manifestVersion.equals("1") || manifestVersion.equals("1.0")) { //$NON-NLS-1$//$NON-NLS-2$
 				continue;
+			}
 
 			String fragmentHost = Utils.getManifestMainAttributes(location, Constants.FRAGMENT_HOST);
-			if (fragmentHost == null)
+			if (fragmentHost == null) {
 				continue;
+			}
 			int index = fragmentHost.indexOf(";"); //$NON-NLS-1$
-			if (index == -1)
+			if (index == -1) {
 				continue;
+			}
 			String symbolicName = fragmentHost.substring(0, index).trim();
 			String parameter = fragmentHost.substring(index + 1).trim();
 			// TODO What to do ,in case of alias name of system bundle is not used ?
-			if (symbolicName.equals(Constants.SYSTEM_BUNDLE_SYMBOLICNAME))
+			if (symbolicName.equals(Constants.SYSTEM_BUNDLE_SYMBOLICNAME)) {
 				if (parameter.equals(Constants.EXTENSION_DIRECTIVE + ":=" + Constants.EXTENSION_FRAMEWORK)) { //$NON-NLS-1$
 					list.add(location);
 					break;
 				}
+			}
 		}
 		return Utils.getBundleInfosFromList(list);
 	}
@@ -218,13 +232,15 @@ public class SimpleBundlesState implements BundlesState {
 		ConfigData configData = manipulator.getConfigData();
 		File fwJar = getFwJar(launcherData);
 
-		if (fwJar == null)
+		if (fwJar == null) {
 			throw new IllegalStateException("launcherData.getLauncherConfigFile() == null && fwJar is not set."); //$NON-NLS-1$
 		// No fw persistent data location is taken into consideration.
+		}
 
 		BundleInfo[] bInfos = configData.getBundles();
-		for (BundleInfo bInfo : bInfos)
+		for (BundleInfo bInfo : bInfos) {
 			this.installBundle(bInfo);
+		}
 
 		if (getSystemBundle() == null) {
 			BundleInfo sysBInfo = new BundleInfo(launcherData.getFwJar().toURI(), 0, true);
@@ -256,11 +272,12 @@ public class SimpleBundlesState implements BundlesState {
 			Dictionary<String, String> manifest = Utils.getOSGiManifest(location);
 			String symbolicName = manifest.get(Constants.BUNDLE_SYMBOLICNAME);
 			String version = manifest.get(Constants.BUNDLE_VERSION);
-			if (newSymbolicName != null && newVersion != null)
+			if (newSymbolicName != null && newVersion != null) {
 				if (newSymbolicName.equals(symbolicName) && newVersion.equals(version)) {
 					found = true;
 					break;
 				}
+			}
 		}
 		if (!found) {
 			this.bundleInfosList.add(bInfo);
@@ -328,8 +345,9 @@ public class SimpleBundlesState implements BundlesState {
 				break;
 			}
 		}
-		if (index != -1)
+		if (index != -1) {
 			this.bundleInfosList.remove(index);
+		}
 	}
 
 }

--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/frameworkadmin/utils/Utils.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/frameworkadmin/utils/Utils.java
@@ -44,10 +44,11 @@ public class Utils {
 	 */
 	public static Properties appendProperties(Properties to, Properties from) {
 		if (from != null) {
-			if (to == null)
+			if (to == null) {
 				to = new Properties();
 			// printoutProperties(System.out, "to", to);
 			// printoutProperties(System.out, "from", from);
+			}
 
 			for (Enumeration<Object> enumeration = from.keys(); enumeration.hasMoreElements();) {
 				String key = (String) enumeration.nextElement();
@@ -75,37 +76,42 @@ public class Utils {
 				} else {
 					// we have a directory-based bundle
 					File bundleManifestFile = new File(bundleLocation, JarFile.MANIFEST_NAME);
-					if (bundleManifestFile.exists())
+					if (bundleManifestFile.exists()) {
 						manifestStream = new BufferedInputStream(
 								new FileInputStream(new File(bundleLocation, JarFile.MANIFEST_NAME)));
+					}
 				}
 			} catch (IOException e) {
 				// ignore
 			}
 			// we were unable to get an OSGi manifest file so try and convert an old-style
 			// manifest
-			if (manifestStream == null)
+			if (manifestStream == null) {
 				return null;
+			}
 
 			try {
 				Map<String, String> manifest = ManifestElement.parseBundleManifest(manifestStream, null);
 				// add this check to handle the case were we read a non-OSGi manifest
-				if (manifest.get(Constants.BUNDLE_SYMBOLICNAME) == null)
+				if (manifest.get(Constants.BUNDLE_SYMBOLICNAME) == null) {
 					return null;
+				}
 				return manifestToProperties(manifest);
 			} catch (IOException | BundleException ioe) {
 				return null;
 			}
 		} finally {
 			try {
-				if (manifestStream != null)
+				if (manifestStream != null) {
 					manifestStream.close();
+				}
 			} catch (IOException e1) {
 				// Ignore
 			}
 			try {
-				if (jarFile != null)
+				if (jarFile != null) {
 					jarFile.close();
+				}
 			} catch (IOException e2) {
 				// Ignore
 			}
@@ -113,35 +119,45 @@ public class Utils {
 	}
 
 	public static void checkAbsoluteDir(File file, String dirName) throws IllegalArgumentException {
-		if (file == null)
+		if (file == null) {
 			throw new IllegalArgumentException(dirName + " is null"); //$NON-NLS-1$
-		if (!file.isAbsolute())
+		}
+		if (!file.isAbsolute()) {
 			throw new IllegalArgumentException(dirName + " is not absolute path. file=" + file.getAbsolutePath()); //$NON-NLS-1$
-		if (!file.isDirectory())
+		}
+		if (!file.isDirectory()) {
 			throw new IllegalArgumentException(dirName + " is not directory. file=" + file.getAbsolutePath()); //$NON-NLS-1$
+		}
 	}
 
 	public static void checkAbsoluteFile(File file, String dirName) {// throws ManipulatorException {
-		if (file == null)
+		if (file == null) {
 			throw new IllegalArgumentException(dirName + " is null"); //$NON-NLS-1$
-		if (!file.isAbsolute())
+		}
+		if (!file.isAbsolute()) {
 			throw new IllegalArgumentException(dirName + " is not absolute path. file=" + file.getAbsolutePath()); //$NON-NLS-1$
-		if (file.isDirectory())
+		}
+		if (file.isDirectory()) {
 			throw new IllegalArgumentException(dirName + " is not file but directory"); //$NON-NLS-1$
+		}
 	}
 
 	public static URL checkFullUrl(URL url, String urlName) throws IllegalArgumentException {// throws
 																								// ManipulatorException
 																								// {
-		if (url == null)
+		if (url == null) {
 			throw new IllegalArgumentException(urlName + " is null"); //$NON-NLS-1$
-		if (!url.getProtocol().endsWith("file")) //$NON-NLS-1$
+		}
+		if (!url.getProtocol().endsWith("file")) { //$NON-NLS-1$
 			return url;
+		}
 		File file = new File(url.getFile());
-		if (!file.isAbsolute())
+		if (!file.isAbsolute()) {
 			throw new IllegalArgumentException(urlName + "(" + url + ") does not have absolute path"); //$NON-NLS-1$ //$NON-NLS-2$
-		if (file.getAbsolutePath().startsWith(PATH_SEP))
+		}
+		if (file.getAbsolutePath().startsWith(PATH_SEP)) {
 			return url;
+		}
 		try {
 			return getUrl("file", null, PATH_SEP + file.getAbsolutePath()); //$NON-NLS-1$
 		} catch (MalformedURLException e) {
@@ -152,16 +168,19 @@ public class Utils {
 
 	public static boolean createParentDir(File file) {
 		File parent = file.getParentFile();
-		if (parent == null)
+		if (parent == null) {
 			return false;
-		if (parent.exists())
+		}
+		if (parent.exists()) {
 			return true;
+		}
 		return parent.mkdirs();
 	}
 
 	public static BundleInfo[] getBundleInfosFromList(List<BundleInfo> list) {
-		if (list == null)
+		if (list == null) {
 			return new BundleInfo[0];
+		}
 		BundleInfo[] ret = new BundleInfo[list.size()];
 		list.toArray(ret);
 		return ret;
@@ -184,17 +203,20 @@ public class Utils {
 
 	public static String getManifestMainAttributes(URI location, String name) {
 		Dictionary<String, String> manifest = Utils.getOSGiManifest(location);
-		if (manifest == null)
+		if (manifest == null) {
 			throw new RuntimeException("Unable to locate bundle manifest: " + location); //$NON-NLS-1$
+		}
 		return manifest.get(name);
 	}
 
 	public static Dictionary<String, String> getOSGiManifest(URI location) {
-		if (location == null)
+		if (location == null) {
 			return null;
+		}
 		// if we have a file-based URL that doesn't end in ".jar" then...
-		if (FILE_SCHEME.equals(location.getScheme()))
+		if (FILE_SCHEME.equals(location.getScheme())) {
 			return basicLoadManifest(URIUtil.toFile(location));
+		}
 
 		try {
 			URL url = new URL("jar:" + location.toString() + "!/"); //$NON-NLS-1$//$NON-NLS-2$
@@ -202,8 +224,9 @@ public class Utils {
 
 			try (ZipFile jar = jarConnection.getJarFile()) {
 				ZipEntry entry = jar.getEntry(JarFile.MANIFEST_NAME);
-				if (entry == null)
+				if (entry == null) {
 					return null;
+				}
 
 				Map<String, String> manifest = ManifestElement.parseBundleManifest(jar.getInputStream(entry), null);
 				// if we have a JAR'd bundle that has a non-OSGi manifest file (like
@@ -225,10 +248,12 @@ public class Utils {
 	}
 
 	public static String getPathFromClause(String clause) {
-		if (clause == null)
+		if (clause == null) {
 			return null;
-		if (clause.indexOf(";") != -1) //$NON-NLS-1$
+		}
+		if (clause.indexOf(";") != -1) { //$NON-NLS-1$
 			clause = clause.substring(0, clause.indexOf(";")); //$NON-NLS-1$
+		}
 		return clause.trim();
 	}
 
@@ -240,21 +265,26 @@ public class Utils {
 		String[] targetTokens = Utils.getTokens(targetPath, PATH_SEP);
 		String[] fromTokens = Utils.getTokens(fromPath, PATH_SEP);
 		int index = -1;
-		for (int i = 0; i < fromTokens.length; i++)
-			if (fromTokens[i].equals(targetTokens[i]))
+		for (int i = 0; i < fromTokens.length; i++) {
+			if (fromTokens[i].equals(targetTokens[i])) {
 				index = i;
-			else
+			} else {
 				break;
+			}
+		}
 
 		StringBuilder sb = new StringBuilder();
-		for (int i = index + 1; i < fromTokens.length; i++)
+		for (int i = index + 1; i < fromTokens.length; i++) {
 			sb.append(".." + PATH_SEP); //$NON-NLS-1$
+		}
 
-		for (int i = index + 1; i < targetTokens.length; i++)
-			if (i != targetTokens.length - 1)
+		for (int i = index + 1; i < targetTokens.length; i++) {
+			if (i != targetTokens.length - 1) {
 				sb.append(targetTokens[i] + PATH_SEP);
-			else
+			} else {
 				sb.append(targetTokens[i]);
+			}
+		}
 		return sb.toString();
 	}
 
@@ -271,10 +301,11 @@ public class Utils {
 		String date = df.format(new Date());
 		String filename = file.getName();
 		int index = filename.lastIndexOf("."); //$NON-NLS-1$
-		if (index != -1)
+		if (index != -1) {
 			filename = filename.substring(0, index) + "." + date + "." + filename.substring(index + 1); //$NON-NLS-1$ //$NON-NLS-2$
-		else
+		} else {
 			filename = filename + "." + date; //$NON-NLS-1$
+		}
 		File dest = new File(file.getParentFile(), filename);
 		return dest;
 	}
@@ -352,8 +383,9 @@ public class Utils {
 	}
 
 	public static String replaceAll(String st, String oldSt, String newSt) {
-		if (oldSt.equals(newSt))
+		if (oldSt.equals(newSt)) {
 			return st;
+		}
 		int index = -1;
 		while ((index = st.indexOf(oldSt)) != -1) {
 			st = st.substring(0, index) + newSt + st.substring(index + oldSt.length());
@@ -374,8 +406,9 @@ public class Utils {
 		SortedMap<Integer, List<BundleInfo>> bslToList = new TreeMap<>();
 		for (BundleInfo bInfo : bInfos) {
 			Integer sL = Integer.valueOf(bInfo.getStartLevel());
-			if (sL.intValue() == BundleInfo.NO_LEVEL)
+			if (sL.intValue() == BundleInfo.NO_LEVEL) {
 				sL = Integer.valueOf(initialBSL);
+			}
 			List<BundleInfo> list = bslToList.get(sL);
 			if (list == null) {
 				list = new LinkedList<>();

--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/ConfigData.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/ConfigData.java
@@ -53,8 +53,9 @@ public class ConfigData {
 	}
 
 	public BundleInfo[] getBundles() {
-		if (bundlesList.size() == 0)
+		if (bundlesList.size() == 0) {
 			return new BundleInfo[0];
+		}
 		BundleInfo[] ret = new BundleInfo[bundlesList.size()];
 		bundlesList.toArray(ret);
 		return ret;
@@ -99,8 +100,9 @@ public class ConfigData {
 	}
 
 	public boolean removeBundle(BundleInfo bundleInfo) {
-		if (bundleInfo == null)
+		if (bundleInfo == null) {
 			throw new IllegalArgumentException("Bundle info can't be null:" + bundleInfo); //$NON-NLS-1$
+		}
 		return bundlesList.remove(bundleInfo);
 	}
 
@@ -110,16 +112,19 @@ public class ConfigData {
 
 	public void setBundles(BundleInfo[] bundleInfos) {
 		bundlesList.clear();
-		if (bundleInfos != null)
-			for (BundleInfo bundleInfo : bundleInfos)
+		if (bundleInfos != null) {
+			for (BundleInfo bundleInfo : bundleInfos) {
 				bundlesList.add(bundleInfo);
+			}
+		}
 	}
 
 	public void setProperty(String key, String value) {
-		if (value == null)
+		if (value == null) {
 			properties.remove(key);
-		else
+		} else {
 			properties.setProperty(key, value);
+		}
 	}
 
 	public void appendProperties(Properties props) {
@@ -146,9 +151,9 @@ public class ConfigData {
 		sb.append("launcherVersion=" + launcherVersion + "\n"); //$NON-NLS-1$ //$NON-NLS-2$
 		sb.append("beginningFwStartLevel=" + beginningFwStartLevel + "\n"); //$NON-NLS-1$ //$NON-NLS-2$
 		sb.append("initialBundleStartLevel=" + initialBundleStartLevel + "\n"); //$NON-NLS-1$ //$NON-NLS-2$
-		if (this.bundlesList.size() == 0)
+		if (this.bundlesList.size() == 0) {
 			sb.append("bundlesList=null\n"); //$NON-NLS-1$
-		else {
+		} else {
 			sb.append("bundlesList=\n"); //$NON-NLS-1$
 			int i = 0;
 			for (BundleInfo bundleInfo : bundlesList) {
@@ -169,11 +174,13 @@ public class ConfigData {
 			for (Enumeration<Object> enumeration = props.keys(); enumeration.hasMoreElements();) {
 				String key = (String) enumeration.nextElement();
 				String value = props.getProperty(key);
-				if (value == null || value.equals("")) //$NON-NLS-1$
+				if (value == null || value.equals("")) { //$NON-NLS-1$
 					continue;
+				}
 				sb.append("\t{" + key + " ,\t" + value + "}\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			}
-		} else
+		} else {
 			sb.append("empty\n"); //$NON-NLS-1$
+		}
 	}
 }

--- a/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/LauncherData.java
+++ b/bundles/org.eclipse.equinox.frameworkadmin/src/org/eclipse/equinox/internal/provisional/frameworkadmin/LauncherData.java
@@ -54,14 +54,16 @@ public class LauncherData {
 	}
 
 	public void addJvmArg(String arg) {
-		if (arg == null)
+		if (arg == null) {
 			return;
+		}
 		jvmArgs.add(arg);
 	}
 
 	public void addProgramArg(String arg) {
-		if (arg == null)
+		if (arg == null) {
 			return;
+		}
 		programArgs.add(arg);
 	}
 
@@ -146,18 +148,21 @@ public class LauncherData {
 		// backwards compatibility we remove all program args until the
 		// next program arg key
 		// (see bug 253862)
-		if (!arg.startsWith("-")) //$NON-NLS-1$
+		if (!arg.startsWith("-")) { //$NON-NLS-1$
 			return;
+		}
 
 		int index = programArgs.indexOf(arg);
-		if (index == -1)
+		if (index == -1) {
 			return;
+		}
 
 		programArgs.remove(index);
 		while (index < programArgs.size()) {
 			String next = programArgs.get(index);
-			if (next.charAt(0) == '-')
+			if (next.charAt(0) == '-') {
 				return;
+			}
 			programArgs.remove(index);
 		}
 	}
@@ -181,8 +186,9 @@ public class LauncherData {
 
 	public void setJvm(File file) {
 		this.jvm = file;
-		if (file == null)
+		if (file == null) {
 			removeProgramArg("-vm"); //$NON-NLS-1$
+		}
 	}
 
 	public void setJvmArgs(String[] args) {
@@ -190,8 +196,9 @@ public class LauncherData {
 			jvmArgs.clear();
 			return;
 		}
-		for (String arg : args)
+		for (String arg : args) {
 			this.addJvmArg(arg);
+		}
 	}
 
 	public void setLauncher(File launcherFile) {
@@ -215,8 +222,9 @@ public class LauncherData {
 			programArgs.clear();
 			return;
 		}
-		for (String arg : args)
+		for (String arg : args) {
 			this.addProgramArg(arg);
+		}
 	}
 
 	@Override
@@ -229,22 +237,24 @@ public class LauncherData {
 		sb.append("launcherVersion=" + this.launcherVersion + "\n"); //$NON-NLS-1$ //$NON-NLS-2$
 
 		sb.append("jvm=" + this.jvm + "\n"); //$NON-NLS-1$ //$NON-NLS-2$
-		if (this.jvmArgs.size() == 0)
+		if (this.jvmArgs.size() == 0) {
 			sb.append("jvmArgs = null\n"); //$NON-NLS-1$
-		else {
+		} else {
 			sb.append("jvmArgs=\n"); //$NON-NLS-1$
 			int i = 0;
-			for (Iterator<String> iterator = jvmArgs.iterator(); iterator.hasNext(); iterator.next())
+			for (Iterator<String> iterator = jvmArgs.iterator(); iterator.hasNext(); iterator.next()) {
 				sb.append("\tjvmArgs[" + i++ + "]=" + iterator + "\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			}
 
 		}
-		if (this.programArgs.size() == 0)
+		if (this.programArgs.size() == 0) {
 			sb.append("programArgs = null\n"); //$NON-NLS-1$
-		else {
+		} else {
 			sb.append("programArgs=\n"); //$NON-NLS-1$
 			int i = 0;
-			for (Iterator<String> iterator = programArgs.iterator(); iterator.hasNext(); iterator.next())
+			for (Iterator<String> iterator = programArgs.iterator(); iterator.hasNext(); iterator.next()) {
 				sb.append("\tprogramArgs[" + i++ + "]=" + iterator + "\n"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			}
 		}
 		sb.append("fwConfigLocation=" + this.fwConfigLocation + "\n"); //$NON-NLS-1$ //$NON-NLS-2$
 		sb.append("fwJar=" + this.fwJar + "\n"); //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

