### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.artifact.repository

### DIFF
--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/pgp/PGPSignatureVerifier.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/processors/pgp/PGPSignatureVerifier.java
@@ -75,8 +75,7 @@ public final class PGPSignatureVerifier extends ProcessingStep {
 			PGPObjectFactory pgpFactory = new BcPGPObjectFactory(in);
 			Object o = pgpFactory.nextObject();
 			PGPSignatureList signatureList = new PGPSignatureList(new PGPSignature[0]);
-			if (o instanceof PGPCompressedData) {
-				PGPCompressedData pgpCompressData = (PGPCompressedData) o;
+			if (o instanceof PGPCompressedData pgpCompressData) {
 				pgpFactory = new BcPGPObjectFactory(pgpCompressData.getDataStream());
 				signatureList = (PGPSignatureList) pgpFactory.nextObject();
 			} else if (o instanceof PGPSignatureList) {

--- a/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactDescriptor.java
+++ b/bundles/org.eclipse.equinox.p2.artifact.repository/src/org/eclipse/equinox/internal/p2/artifact/repository/simple/SimpleArtifactDescriptor.java
@@ -86,11 +86,9 @@ public class SimpleArtifactDescriptor extends ArtifactDescriptor {
 		if (this == obj) {
 			return true;
 		}
-		if (obj == null || !(obj instanceof SimpleArtifactDescriptor)) {
+		if (obj == null || !(obj instanceof SimpleArtifactDescriptor other)) {
 			return false;
 		}
-
-		SimpleArtifactDescriptor other = (SimpleArtifactDescriptor) obj;
 
 		//Properties affecting SimpleArtifactRepository#getLocation
 		String locationProperty = getRepositoryProperty(ARTIFACT_REFERENCE);


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

