### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.engine

### DIFF
--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/DebugHelper.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/DebugHelper.java
@@ -109,8 +109,7 @@ public class DebugHelper {
 	public static String formatOperands(Operand[] operands) {
 		String[] operandStrings = new String[operands.length];
 		for (int i = 0; i < operands.length; i++) {
-			if (operands[i] instanceof InstallableUnitOperand) {
-				InstallableUnitOperand iuOperand = (InstallableUnitOperand) operands[i];
+			if (operands[i] instanceof InstallableUnitOperand iuOperand) {
 				operandStrings[i] = formatInstallableUnitOperand(iuOperand);
 			} else {
 				operandStrings[i] = operands[i].toString();
@@ -146,8 +145,7 @@ public class DebugHelper {
 	public static String formatAction(ProvisioningAction action, Map<String, Object> parameters) {
 		StringBuilder buffer = new StringBuilder();
 		buffer.append(action.getClass().getName());
-		if (action instanceof ParameterizedProvisioningAction) {
-			ParameterizedProvisioningAction parameterizedAction = (ParameterizedProvisioningAction) action;
+		if (action instanceof ParameterizedProvisioningAction parameterizedAction) {
 			buffer.append("{action=" + parameterizedAction.getAction().getClass().getName()); //$NON-NLS-1$
 			buffer.append(", actionText=" + parameterizedAction.getActionText() + "}"); //$NON-NLS-1$ //$NON-NLS-2$
 		}

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/EngineSession.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/EngineSession.java
@@ -380,8 +380,7 @@ public class EngineSession {
 	}
 
 	public String getContextString(Phase phase, Operand operand, ProvisioningAction action) {
-		if (action instanceof ParameterizedProvisioningAction) {
-			ParameterizedProvisioningAction parameterizedAction = (ParameterizedProvisioningAction) action;
+		if (action instanceof ParameterizedProvisioningAction parameterizedAction) {
 			action = parameterizedAction.getAction();
 		}
 		String message = NLS.bind(Messages.session_context, new Object[] {profile.getProfileId(), phase.getClass().getName(), operand.toString(), getCurrentActionId()});
@@ -399,8 +398,7 @@ public class EngineSession {
 		}
 
 		Object currentAction = currentRecord.actions.get(currentRecord.actions.size() - 1);
-		if (currentAction instanceof ParameterizedProvisioningAction) {
-			ParameterizedProvisioningAction parameterizedAction = (ParameterizedProvisioningAction) currentAction;
+		if (currentAction instanceof ParameterizedProvisioningAction parameterizedAction) {
 			currentAction = parameterizedAction.getAction();
 		}
 		return currentAction.getClass().getName();

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/InstallableUnitPhase.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/InstallableUnitPhase.java
@@ -77,11 +77,10 @@ public abstract class InstallableUnitPhase extends Phase {
 
 	@Override
 	final protected List<ProvisioningAction> getActions(Operand operand) {
-		if (!(operand instanceof InstallableUnitOperand)) {
+		if (!(operand instanceof InstallableUnitOperand iuOperand)) {
 			return null;
 		}
 
-		InstallableUnitOperand iuOperand = (InstallableUnitOperand) operand;
 		return getActions(iuOperand);
 	}
 
@@ -89,11 +88,10 @@ public abstract class InstallableUnitPhase extends Phase {
 
 	@Override
 	final public boolean isApplicable(Operand operand) {
-		if (!(operand instanceof InstallableUnitOperand)) {
+		if (!(operand instanceof InstallableUnitOperand iuOperand)) {
 			return false;
 		}
 
-		InstallableUnitOperand iuOperand = (InstallableUnitOperand) operand;
 		return isApplicable(iuOperand);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Profile.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/Profile.java
@@ -216,10 +216,9 @@ public class Profile extends IndexProvider<IInstallableUnit> implements IProfile
 
 	@Override
 	public Object getManagedProperty(Object client, String memberName, Object key) {
-		if (!(client instanceof IInstallableUnit)) {
+		if (!(client instanceof IInstallableUnit iu)) {
 			return null;
 		}
-		IInstallableUnit iu = (IInstallableUnit) client;
 		if (InstallableUnit.MEMBER_PROFILE_PROPERTIES.equals(memberName) && key instanceof String) {
 			return getInstallableUnitProperty(iu, (String) key);
 		}

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/Property.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/internal/p2/engine/phases/Property.java
@@ -56,8 +56,7 @@ public class Property extends Phase {
 
 			String value = (String) (undo ? propertyOperand.first() : propertyOperand.second());
 
-			if (propertyOperand instanceof InstallableUnitPropertyOperand) {
-				InstallableUnitPropertyOperand iuPropertyOperand = (InstallableUnitPropertyOperand) propertyOperand;
+			if (propertyOperand instanceof InstallableUnitPropertyOperand iuPropertyOperand) {
 				profile.setInstallableUnitProperty(iuPropertyOperand.getInstallableUnit(), iuPropertyOperand.getKey(), value);
 			} else {
 				profile.setProperty(propertyOperand.getKey(), value);
@@ -65,8 +64,7 @@ public class Property extends Phase {
 		}
 
 		private void removeProfileProperty(Profile profile, PropertyOperand propertyOperand) {
-			if (propertyOperand instanceof InstallableUnitPropertyOperand) {
-				InstallableUnitPropertyOperand iuPropertyOperand = (InstallableUnitPropertyOperand) propertyOperand;
+			if (propertyOperand instanceof InstallableUnitPropertyOperand iuPropertyOperand) {
 				profile.removeInstallableUnitProperty(iuPropertyOperand.getInstallableUnit(), iuPropertyOperand.getKey());
 			} else {
 				profile.removeProperty(propertyOperand.getKey());
@@ -155,8 +153,7 @@ public class Property extends Phase {
 			return Collections.singletonList(new ProfilePropertyAction());
 		}
 
-		if (operand instanceof InstallableUnitOperand) {
-			InstallableUnitOperand iuOperand = (InstallableUnitOperand) operand;
+		if (operand instanceof InstallableUnitOperand iuOperand) {
 			if (iuOperand.first() != null) {
 				if (iuOperand.second() != null) {
 					return Collections.singletonList(new UpdateInstallableUnitProfilePropertiesAction());

--- a/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/ProfileScope.java
+++ b/bundles/org.eclipse.equinox.p2.engine/src/org/eclipse/equinox/p2/engine/ProfileScope.java
@@ -86,10 +86,9 @@ public final class ProfileScope implements IScopeContext {
 		if (!super.equals(obj)) {
 			return false;
 		}
-		if (!(obj instanceof ProfileScope)) {
+		if (!(obj instanceof ProfileScope other)) {
 			return false;
 		}
-		ProfileScope other = (ProfileScope) obj;
 		return profileId.equals(other.profileId);
 	}
 


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

