### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.extensionlocation

### DIFF
--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/Activator.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/Activator.java
@@ -53,11 +53,13 @@ public class Activator implements BundleActivator {
 	 */
 	public static File getConfigurationLocation() {
 		Location configurationLocation = ServiceHelper.getService(getContext(), Location.class, Location.CONFIGURATION_FILTER);
-		if (configurationLocation == null || !configurationLocation.isSet())
+		if (configurationLocation == null || !configurationLocation.isSet()) {
 			return null;
+		}
 		URL url = configurationLocation.getURL();
-		if (url == null)
+		if (url == null) {
 			return null;
+		}
 		return URLUtil.toFile(url);
 	}
 
@@ -68,19 +70,22 @@ public class Activator implements BundleActivator {
 
 	public static IProvisioningAgent getCurrentAgent() {
 		ServiceReference<IProvisioningAgent> reference = bundleContext.getServiceReference(IProvisioningAgent.class);
-		if (reference == null)
+		if (reference == null) {
 			return null;
+		}
 		return bundleContext.getService(reference);
 	}
 
 	public static IFileArtifactRepository getBundlePoolRepository() {
 		IProvisioningAgent agent = getCurrentAgent();
-		if (agent == null)
+		if (agent == null) {
 			return null;
+		}
 
 		IProfile profile = getCurrentProfile();
-		if (profile == null)
+		if (profile == null) {
 			return null;
+		}
 
 		return Util.getAggregatedBundleRepository(agent, profile, Util.AGGREGATE_CACHE | Util.AGGREGATE_SHARED_CACHE);
 	}

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/BundlePoolFilteredListener.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/BundlePoolFilteredListener.java
@@ -31,8 +31,9 @@ public class BundlePoolFilteredListener extends DirectoryChangeListener {
 		if (bundlePool != null) {
 			for (IArtifactKey key : bundlePool.query(ArtifactKeyQuery.ALL_KEYS, null)) {
 				File artifactFile = bundlePool.getArtifactFile(key);
-				if (artifactFile != null)
+				if (artifactFile != null) {
 					bundlePoolFiles.add(artifactFile);
+				}
 			}
 		}
 	}
@@ -54,8 +55,9 @@ public class BundlePoolFilteredListener extends DirectoryChangeListener {
 
 	@Override
 	public boolean isInterested(File file) {
-		if (bundlePoolFiles.contains(file))
+		if (bundlePoolFiles.contains(file)) {
 			return false;
+		}
 
 		return delegate.isInterested(file);
 	}

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationArtifactRepository.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationArtifactRepository.java
@@ -62,8 +62,9 @@ public class ExtensionLocationArtifactRepository extends AbstractRepository<IArt
 	}
 
 	public synchronized void ensureInitialized() {
-		if (state == SiteListener.INITIALIZED || state == SiteListener.INITIALIZING)
+		if (state == SiteListener.INITIALIZED || state == SiteListener.INITIALIZING) {
 			return;
+		}
 		// if the repo has not been synchronized for us already, synchronize it.
 		// Note: this will reload "artifactRepository"
 		SiteListener.synchronizeRepositories(null, this, base);
@@ -89,8 +90,9 @@ public class ExtensionLocationArtifactRepository extends AbstractRepository<IArt
 
 	public static void validate(URI location, IProgressMonitor monitor) throws ProvisionException {
 		File base = getBaseDirectory(location);
-		if (new File(base, EXTENSION_LOCATION).exists() || location.getPath().endsWith(EXTENSION_LOCATION))
+		if (new File(base, EXTENSION_LOCATION).exists() || location.getPath().endsWith(EXTENSION_LOCATION)) {
 			return;
+		}
 		if (containsUpdateSiteFile(base)) {
 			String message = NLS.bind(Messages.error_update_site, location.toString());
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND, message, null));
@@ -108,8 +110,9 @@ public class ExtensionLocationArtifactRepository extends AbstractRepository<IArt
 
 	private static boolean containsUpdateSiteFile(File base) {
 		String[] fileNames = base.list();
-		if (fileNames == null)
+		if (fileNames == null) {
 			return false;
+		}
 		for (String fileName : fileNames) {
 			if (fileName.endsWith(DOT_XML) && fileName.contains(SITE)) {
 				return true;
@@ -119,23 +122,28 @@ public class ExtensionLocationArtifactRepository extends AbstractRepository<IArt
 	}
 
 	public static File getBaseDirectory(URI uri) throws ProvisionException {
-		if (!FILE.equals(uri.getScheme()))
+		if (!FILE.equals(uri.getScheme())) {
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND, Messages.not_file_protocol, null));
+		}
 
 		String path = URIUtil.toFile(uri).getAbsolutePath();
-		if (path.endsWith(EXTENSION_LOCATION))
+		if (path.endsWith(EXTENSION_LOCATION)) {
 			path = path.substring(0, path.length() - EXTENSION_LOCATION.length());
+		}
 		File base = new File(path);
 
-		if (!base.isDirectory())
+		if (!base.isDirectory()) {
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND, NLS.bind(Messages.not_directory, uri.toString()), null));
+		}
 
-		if (isBaseDirectory(base))
+		if (isBaseDirectory(base)) {
 			return base;
+		}
 
 		File eclipseBase = new File(base, ECLIPSE);
-		if (isBaseDirectory(eclipseBase))
+		if (isBaseDirectory(eclipseBase)) {
 			return eclipseBase;
+		}
 
 		throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND, NLS.bind(Messages.not_eclipse_extension, uri.toString()), null));
 	}
@@ -290,17 +298,20 @@ public class ExtensionLocationArtifactRepository extends AbstractRepository<IArt
 			ensureInitialized();
 			String oldValue = artifactRepository.setProperty(key, value);
 			// if the value didn't really change then just return
-			if (oldValue == value || (oldValue != null && oldValue.equals(value)))
+			if (oldValue == value || (oldValue != null && oldValue.equals(value))) {
 				return oldValue;
+			}
 			// we want to re-initialize if we are changing the site policy or plug-in list
-			if (!SiteListener.SITE_LIST.equals(key) && !SiteListener.SITE_POLICY.equals(key))
+			if (!SiteListener.SITE_LIST.equals(key) && !SiteListener.SITE_POLICY.equals(key)) {
 				return oldValue;
+			}
 			state = SiteListener.UNINITIALIZED;
 			ensureInitialized();
 			return oldValue;
 		} finally {
-			if (monitor != null)
+			if (monitor != null) {
 				monitor.done();
+			}
 		}
 	}
 

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationArtifactRepositoryFactory.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationArtifactRepositoryFactory.java
@@ -30,12 +30,14 @@ public class ExtensionLocationArtifactRepositoryFactory extends ArtifactReposito
 	public IArtifactRepository create(URI location, String name, String type, Map<String, String> properties) throws ProvisionException {
 		// TODO proper progress monitoring
 		IStatus status = validate(location, null);
-		if (!status.isOK())
+		if (!status.isOK()) {
 			throw new ProvisionException(status);
+		}
 		URI repoLocation = ExtensionLocationArtifactRepository.getLocalRepositoryLocation(location);
 		// unexpected
-		if (repoLocation == null)
+		if (repoLocation == null) {
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, Messages.failed_create_local_artifact_repository));
+		}
 		// make sure that we aren't trying to create a repo at a location
 		// where one already exists
 		boolean failed = false;
@@ -64,12 +66,14 @@ public class ExtensionLocationArtifactRepositoryFactory extends ArtifactReposito
 
 		// TODO proper progress monitoring
 		IStatus status = validate(location, null);
-		if (!status.isOK())
+		if (!status.isOK()) {
 			throw new ProvisionException(status);
+		}
 		URI repoLocation = ExtensionLocationArtifactRepository.getLocalRepositoryLocation(location);
 		// unexpected
-		if (repoLocation == null)
+		if (repoLocation == null) {
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, Messages.failed_create_local_artifact_repository));
+		}
 		// TODO proper progress monitoring
 		try {
 			final SimpleArtifactRepositoryFactory simpleFactory = new SimpleArtifactRepositoryFactory();

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationMetadataRepository.java
@@ -61,8 +61,9 @@ public class ExtensionLocationMetadataRepository extends AbstractMetadataReposit
 	}
 
 	public synchronized void ensureInitialized() {
-		if (state == SiteListener.INITIALIZED || state == SiteListener.INITIALIZING)
+		if (state == SiteListener.INITIALIZED || state == SiteListener.INITIALIZING) {
 			return;
+		}
 		// if the repo has not been synchronized for us already, synchronize it.
 		// Note: this will reload "metadataRepository"
 		SiteListener.synchronizeRepositories(this, null, base);
@@ -119,8 +120,9 @@ public class ExtensionLocationMetadataRepository extends AbstractMetadataReposit
 
 	public static void validate(URI location, IProgressMonitor monitor) throws ProvisionException {
 		File base = getBaseDirectory(location);
-		if (new File(base, EXTENSION_LOCATION).exists() || location.getPath().endsWith(EXTENSION_LOCATION))
+		if (new File(base, EXTENSION_LOCATION).exists() || location.getPath().endsWith(EXTENSION_LOCATION)) {
 			return;
+		}
 		if (containsUpdateSiteFile(base)) {
 			String message = NLS.bind(Messages.error_update_site, location.toString());
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND, message, null));
@@ -138,8 +140,9 @@ public class ExtensionLocationMetadataRepository extends AbstractMetadataReposit
 
 	private static boolean containsUpdateSiteFile(File base) {
 		String[] fileNames = base.list();
-		if (fileNames == null)
+		if (fileNames == null) {
 			return false;
+		}
 		for (String fileName : fileNames) {
 			if (fileName.endsWith(DOT_XML) && fileName.contains(SITE)) {
 				return true;
@@ -149,23 +152,28 @@ public class ExtensionLocationMetadataRepository extends AbstractMetadataReposit
 	}
 
 	public static File getBaseDirectory(URI uri) throws ProvisionException {
-		if (!FILE.equals(uri.getScheme()))
+		if (!FILE.equals(uri.getScheme())) {
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND, Messages.not_file_protocol, null));
+		}
 
 		File base = URIUtil.toFile(uri);
 		String path = base.getAbsolutePath();
-		if (path.endsWith(EXTENSION_LOCATION))
+		if (path.endsWith(EXTENSION_LOCATION)) {
 			base = new File(path.substring(0, path.length() - EXTENSION_LOCATION.length()));
+		}
 
-		if (!base.isDirectory())
+		if (!base.isDirectory()) {
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND, NLS.bind(Messages.not_directory, uri.toString()), null));
+		}
 
-		if (isBaseDirectory(base))
+		if (isBaseDirectory(base)) {
 			return base;
+		}
 
 		File eclipseBase = new File(base, ECLIPSE);
-		if (isBaseDirectory(eclipseBase))
+		if (isBaseDirectory(eclipseBase)) {
 			return eclipseBase;
+		}
 
 		throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, ProvisionException.REPOSITORY_NOT_FOUND, NLS.bind(Messages.not_eclipse_extension, uri.toString()), null));
 	}
@@ -194,17 +202,20 @@ public class ExtensionLocationMetadataRepository extends AbstractMetadataReposit
 			ensureInitialized();
 			String oldValue = metadataRepository.setProperty(key, value);
 			// if the value didn't really change then just return
-			if (oldValue == value || (oldValue != null && oldValue.equals(value)))
+			if (oldValue == value || (oldValue != null && oldValue.equals(value))) {
 				return oldValue;
+			}
 			// we want to re-initialize if we are changing the site policy or plug-in list
-			if (!SiteListener.SITE_LIST.equals(key) && !SiteListener.SITE_POLICY.equals(key))
+			if (!SiteListener.SITE_LIST.equals(key) && !SiteListener.SITE_POLICY.equals(key)) {
 				return oldValue;
+			}
 			state = SiteListener.UNINITIALIZED;
 			ensureInitialized();
 			return oldValue;
 		} finally {
-			if (monitor != null)
+			if (monitor != null) {
 				monitor.done();
+			}
 		}
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationMetadataRepositoryFactory.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/ExtensionLocationMetadataRepositoryFactory.java
@@ -29,12 +29,14 @@ public class ExtensionLocationMetadataRepositoryFactory extends MetadataReposito
 	public IMetadataRepository create(URI location, String name, String type, Map<String, String> properties) throws ProvisionException {
 		// TODO proper progress monitoring
 		IStatus status = validate(location, null);
-		if (!status.isOK())
+		if (!status.isOK()) {
 			throw new ProvisionException(status);
+		}
 		URI repoLocation = ExtensionLocationMetadataRepository.getLocalRepositoryLocation(location);
 		// unexpected
-		if (repoLocation == null)
+		if (repoLocation == null) {
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, Messages.failed_create_local_artifact_repository));
+		}
 		// ensure that we aren't trying to create a repository at a location
 		// where one already exists
 		boolean failed = false;
@@ -63,12 +65,14 @@ public class ExtensionLocationMetadataRepositoryFactory extends MetadataReposito
 
 		// TODO proper progress monitoring
 		IStatus status = validate(location, null);
-		if (!status.isOK())
+		if (!status.isOK()) {
 			throw new ProvisionException(status);
+		}
 		URI repoLocation = ExtensionLocationMetadataRepository.getLocalRepositoryLocation(location);
 		// unexpected
-		if (repoLocation == null)
+		if (repoLocation == null) {
 			throw new ProvisionException(new Status(IStatus.ERROR, Activator.ID, Messages.failed_create_local_artifact_repository));
+		}
 		// TODO proper progress monitoring
 		try {
 			final SimpleMetadataRepositoryFactory simpleFactory = new SimpleMetadataRepositoryFactory();

--- a/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/SiteListener.java
+++ b/bundles/org.eclipse.equinox.p2.extensionlocation/src/org/eclipse/equinox/internal/p2/extensionlocation/SiteListener.java
@@ -66,8 +66,9 @@ public class SiteListener extends DirectoryChangeListener {
 	 * Converts a list of file names to a normalized form suitable for comparison.
 	 */
 	private String[] normalize(String[] filenames) {
-		for (int i = 0; i < filenames.length; i++)
+		for (int i = 0; i < filenames.length; i++) {
 			filenames[i] = new File(filenames[i]).toString();
+		}
 		return filenames;
 	}
 
@@ -107,8 +108,9 @@ public class SiteListener extends DirectoryChangeListener {
 		//  here we have to sync with the inner repos as the extension location repos are 
 		// read-only wrappers.
 		DirectoryChangeListener listener = new RepositoryListener(metadataRepository.metadataRepository, artifactRepository.artifactRepository);
-		if (metadataRepository.getProperties().get(SiteListener.SITE_POLICY) != null)
+		if (metadataRepository.getProperties().get(SiteListener.SITE_POLICY) != null) {
 			listener = new SiteListener(metadataRepository.getProperties(), metadataRepository.getLocation().toString(), new BundlePoolFilteredListener(listener));
+		}
 		watcher.addListener(listener);
 		watcher.poll();
 		artifactRepository.state(INITIALIZED);
@@ -124,9 +126,11 @@ public class SiteListener extends DirectoryChangeListener {
 		this.policy = properties.get(SITE_POLICY);
 		Collection<String> listCollection = new HashSet<>();
 		String listString = properties.get(SITE_LIST);
-		if (listString != null)
-			for (StringTokenizer tokenizer = new StringTokenizer(listString, ","); tokenizer.hasMoreTokens();) //$NON-NLS-1$
+		if (listString != null) {
+			for (StringTokenizer tokenizer = new StringTokenizer(listString, ","); tokenizer.hasMoreTokens();) { //$NON-NLS-1$
 				listCollection.add(tokenizer.nextToken());
+			}
+		}
 		this.list = normalize(listCollection.toArray(new String[listCollection.size()]));
 	}
 
@@ -134,19 +138,22 @@ public class SiteListener extends DirectoryChangeListener {
 	public boolean isInterested(File file) {
 		// make sure that our delegate and super-class are both interested in 
 		// the file before we consider it
-		if (!delegate.isInterested(file))
+		if (!delegate.isInterested(file)) {
 			return false;
+		}
 		if (Site.POLICY_MANAGED_ONLY.equals(policy)) {
 			// we only want plug-ins referenced by features
 			return contains(getManagedFiles(), file);
 		} else if (Site.POLICY_USER_EXCLUDE.equals(policy)) {
 			// ensure the file doesn't refer to a plug-in in our list
-			if (contains(list, file))
+			if (contains(list, file)) {
 				return false;
+			}
 		} else if (Site.POLICY_USER_INCLUDE.equals(policy)) {
 			// we are only interested in plug-ins in the list
-			if (!contains(list, file))
+			if (!contains(list, file)) {
 				return false;
+			}
 		} else {
 			// shouldn't happen... unknown policy type
 			return false;
@@ -164,15 +171,18 @@ public class SiteListener extends DirectoryChangeListener {
 	 */
 	private boolean isToBeRemoved(File file) {
 		String[] removed = getToBeRemoved();
-		if (removed.length == 0)
+		if (removed.length == 0) {
 			return false;
+		}
 		Feature feature = getFeature(file);
-		if (feature == null)
+		if (feature == null) {
 			return false;
+		}
 		for (String line : removed) {
 			// the line is a versioned identifier which is id_version
-			if (line.equals(feature.getId() + '_' + feature.getVersion()))
+			if (line.equals(feature.getId() + '_' + feature.getVersion())) {
 				return true;
+			}
 		}
 		return false;
 	}
@@ -182,11 +192,13 @@ public class SiteListener extends DirectoryChangeListener {
 	 * Can return null.
 	 */
 	private Feature getFeature(File location) {
-		if (location.isFile())
+		if (location.isFile()) {
 			return null;
+		}
 		File manifest = new File(location, FEATURE_MANIFEST);
-		if (!manifest.exists())
+		if (!manifest.exists()) {
 			return null;
+		}
 		FeatureParser parser = new FeatureParser();
 		return parser.parse(location);
 	}
@@ -197,8 +209,9 @@ public class SiteListener extends DirectoryChangeListener {
 	 * The strings are in the format of versioned identifiers: id_version
 	 */
 	private String[] getToBeRemoved() {
-		if (toBeRemoved != null)
+		if (toBeRemoved != null) {
 			return toBeRemoved;
+		}
 		File configurationLocation = Activator.getConfigurationLocation();
 		if (configurationLocation == null) {
 			LogHelper.log(new Status(IStatus.ERROR, Activator.ID, "Unable to compute the configuration location.")); //$NON-NLS-1$
@@ -219,8 +232,9 @@ public class SiteListener extends DirectoryChangeListener {
 			// TODO
 		}
 		String urlString = siteLocation;
-		if (urlString.endsWith(Constants.EXTENSION_LOCATION))
+		if (urlString.endsWith(Constants.EXTENSION_LOCATION)) {
 			urlString = urlString.substring(0, urlString.length() - Constants.EXTENSION_LOCATION.length());
+		}
 		List<String> result = new ArrayList<>();
 		for (Enumeration<Object> e = properties.elements(); e.hasMoreElements();) {
 			String line = (String) e.nextElement();
@@ -229,8 +243,9 @@ public class SiteListener extends DirectoryChangeListener {
 			try {
 				// the urlString is coming from the site location which is an encoded URI
 				// so we need to encode the targetSite string before we check for equality
-				if (!urlString.equals(URIUtil.fromString(targetSite).toString()))
+				if (!urlString.equals(URIUtil.fromString(targetSite).toString())) {
 					continue;
+				}
 			} catch (URISyntaxException e1) {
 				// shouldn't happen
 				e1.printStackTrace();
@@ -248,8 +263,9 @@ public class SiteListener extends DirectoryChangeListener {
 	 * features.
 	 */
 	private String[] getManagedFiles() {
-		if (managedFiles != null)
+		if (managedFiles != null) {
 			return managedFiles;
+		}
 		List<String> result = new ArrayList<>();
 		File siteFile;
 		try {
@@ -269,8 +285,9 @@ public class SiteListener extends DirectoryChangeListener {
 				// grab the right location from the plug-in cache
 				String key = entry.getId() + '/' + entry.getVersion();
 				File pluginLocation = pluginCache.get(key);
-				if (pluginLocation != null)
+				if (pluginLocation != null) {
 					result.add(pluginLocation.toString());
+				}
 			}
 		}
 		managedFiles = normalize(result.toArray(new String[result.size()]));
@@ -290,8 +307,9 @@ public class SiteListener extends DirectoryChangeListener {
 			if (featureLocation.isDirectory() && featureLocation.getParentFile() != null && featureLocation.getParentFile().getName().equals("features") && new File(featureLocation, "feature.xml").exists()) {//$NON-NLS-1$ //$NON-NLS-2$
 				FeatureParser parser = new FeatureParser();
 				Feature entry = parser.parse(featureLocation);
-				if (entry != null)
+				if (entry != null) {
 					result.put(featureLocation, entry);
+				}
 			}
 		}
 		return result;


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

