### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.garbagecollector

### DIFF
--- a/bundles/org.eclipse.equinox.p2.garbagecollector/src/org/eclipse/equinox/internal/p2/garbagecollector/GarbageCollector.java
+++ b/bundles/org.eclipse.equinox.p2.garbagecollector/src/org/eclipse/equinox/internal/p2/garbagecollector/GarbageCollector.java
@@ -145,8 +145,7 @@ public class GarbageCollector implements SynchronousProvisioningListener, IAgent
 
 	@Override
 	public void notify(EventObject o) {
-		if (o instanceof InstallableUnitEvent) {
-			InstallableUnitEvent event = (InstallableUnitEvent) o;
+		if (o instanceof InstallableUnitEvent event) {
 			if (event.isUninstall() && event.isPost()) {
 				uninstallEventProfileId = event.getProfile().getProfileId();
 			}


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

