### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.metadata.repository

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/LocalMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/LocalMetadataRepository.java
@@ -159,10 +159,9 @@ public class LocalMetadataRepository extends AbstractMetadataRepository implemen
 
 	@Override
 	public synchronized Object getManagedProperty(Object client, String memberName, Object key) {
-		if (!(client instanceof IInstallableUnit)) {
+		if (!(client instanceof IInstallableUnit iu)) {
 			return null;
 		}
-		IInstallableUnit iu = (IInstallableUnit) client;
 		if (InstallableUnit.MEMBER_TRANSLATED_PROPERTIES.equals(memberName)) {
 			if (translationSupport == null) {
 				translationSupport = new TranslationSupport(this);

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/URLMetadataRepository.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/URLMetadataRepository.java
@@ -133,10 +133,9 @@ public class URLMetadataRepository extends AbstractMetadataRepository implements
 
 	@Override
 	public synchronized Object getManagedProperty(Object client, String memberName, Object key) {
-		if (!(client instanceof IInstallableUnit)) {
+		if (!(client instanceof IInstallableUnit iu)) {
 			return null;
 		}
-		IInstallableUnit iu = (IInstallableUnit) client;
 		if (InstallableUnit.MEMBER_TRANSLATED_PROPERTIES.equals(memberName)) {
 			if (translationSupport == null) {
 				translationSupport = new TranslationSupport(this);

--- a/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/io/MetadataWriter.java
+++ b/bundles/org.eclipse.equinox.p2.metadata.repository/src/org/eclipse/equinox/internal/p2/metadata/repository/io/MetadataWriter.java
@@ -65,13 +65,11 @@ public class MetadataWriter extends XMLWriter implements XMLConstants {
 			attribute(GENERATION_ATTRIBUTE, 2);
 		}
 
-		if (iu instanceof IInstallableUnitFragment) {
-			IInstallableUnitFragment fragment = (IInstallableUnitFragment) iu;
+		if (iu instanceof IInstallableUnitFragment fragment) {
 			writeHostRequirements(fragment.getHost());
 		}
 
-		if (iu instanceof IInstallableUnitPatch) {
-			IInstallableUnitPatch patch = (IInstallableUnitPatch) iu;
+		if (iu instanceof IInstallableUnitPatch patch) {
 			writeApplicabilityScope(patch.getApplicabilityScope());
 			writeRequirementsChange(patch.getRequirementsChange());
 			writeLifeCycle(patch.getLifeCycle());
@@ -128,8 +126,7 @@ public class MetadataWriter extends XMLWriter implements XMLConstants {
 			}
 		}
 
-		if (iu instanceof IInstallableUnitPatch) {
-			IInstallableUnitPatch iuPatch = (IInstallableUnitPatch) iu;
+		if (iu instanceof IInstallableUnitPatch iuPatch) {
 			for (IRequirement[] rArr : iuPatch.getApplicabilityScope()) {
 				for (IRequirement r : rArr) {
 					if (!RequiredCapability.isVersionRangeRequirement(r.getMatches())) {


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

