### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.metadata

### DIFF
--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/License.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/License.java
@@ -104,8 +104,7 @@ public class License implements ILicense {
 		if (obj == null) {
 			return false;
 		}
-		if (obj instanceof ILicense) {
-			ILicense other = (ILicense) obj;
+		if (obj instanceof ILicense other) {
 			if (other.getUUID().equals(getUUID())) {
 				return true;
 			}

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OSGiVersion.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OSGiVersion.java
@@ -56,11 +56,10 @@ public class OSGiVersion extends BasicVersion {
 			return true;
 		}
 
-		if (!(e instanceof String)) {
+		if (!(e instanceof String s)) {
 			return false;
 		}
 
-		String s = (String) e;
 		int idx = s.length();
 		boolean[] allowed = allowedOSGiChars;
 		while (--idx >= 0) {
@@ -110,11 +109,10 @@ public class OSGiVersion extends BasicVersion {
 	@Override
 	public int compareTo(Version v) {
 		int result;
-		if (!(v instanceof OSGiVersion)) {
+		if (!(v instanceof OSGiVersion ov)) {
 			BasicVersion ov = (BasicVersion) v;
 			result = VersionVector.compare(getVector(), null, ov.getVector(), ov.getPad());
 		} else {
-			OSGiVersion ov = (OSGiVersion) v;
 			result = major - ov.major;
 			if (result == 0) {
 				result = minor - ov.minor;
@@ -135,15 +133,13 @@ public class OSGiVersion extends BasicVersion {
 			return true;
 		}
 
-		if (!(object instanceof OSGiVersion)) {
-			if (object instanceof BasicVersion) {
-				BasicVersion ov = (BasicVersion) object;
+		if (!(object instanceof OSGiVersion other)) {
+			if (object instanceof BasicVersion ov) {
 				return VersionVector.equals(getVector(), null, ov.getVector(), ov.getPad());
 			}
 			return false;
 		}
 
-		OSGiVersion other = (OSGiVersion) object;
 		return micro == other.micro && minor == other.minor && major == other.major && qualifier.equals(other.qualifier);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OmniVersion.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/OmniVersion.java
@@ -110,11 +110,10 @@ public class OmniVersion extends BasicVersion {
 			return true;
 		}
 
-		if (!(o instanceof BasicVersion)) {
+		if (!(o instanceof BasicVersion ov)) {
 			return false;
 		}
 
-		BasicVersion ov = (BasicVersion) o;
 		return VersionVector.equals(vector, padValue, ov.getVector(), ov.getPad());
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/RequirementChange.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/RequirementChange.java
@@ -69,10 +69,9 @@ public class RequirementChange implements IRequirementChange {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof IRequirementChange)) {
+		if (!(obj instanceof final IRequirementChange other)) {
 			return false;
 		}
-		final IRequirementChange other = (IRequirementChange) obj;
 		if (applyOn == null) {
 			if (other.applyOn() != null) {
 				return false;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TouchpointData.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TouchpointData.java
@@ -50,10 +50,9 @@ public class TouchpointData implements ITouchpointData {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof ITouchpointData)) {
+		if (!(obj instanceof final ITouchpointData other)) {
 			return false;
 		}
-		final ITouchpointData other = (ITouchpointData) obj;
 		if (instructions == null) {
 			if (other.getInstructions() != null) {
 				return false;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TouchpointInstruction.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TouchpointInstruction.java
@@ -112,10 +112,9 @@ public class TouchpointInstruction implements ITouchpointInstruction {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof ITouchpointInstruction)) {
+		if (!(obj instanceof ITouchpointInstruction other)) {
 			return false;
 		}
-		ITouchpointInstruction other = (ITouchpointInstruction) obj;
 		if (body == null) {
 			if (other.getBody() != null) {
 				return false;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TouchpointType.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/TouchpointType.java
@@ -38,10 +38,9 @@ public class TouchpointType implements ITouchpointType {
 		if (super.equals(obj)) {
 			return true;
 		}
-		if (obj == null || !(obj instanceof ITouchpointType)) {
+		if (obj == null || !(obj instanceof ITouchpointType other)) {
 			return false;
 		}
-		ITouchpointType other = (ITouchpointType) obj;
 		return id.equals(other.getId()) && version.equals(other.getVersion());
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionFormatParser.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionFormatParser.java
@@ -205,10 +205,9 @@ class VersionFormatParser {
 			if (o == this) {
 				return true;
 			}
-			if (!(o instanceof Qualifier)) {
+			if (!(o instanceof Qualifier oq)) {
 				return false;
 			}
-			Qualifier oq = (Qualifier) o;
 			return min == oq.min && max == oq.max;
 		}
 
@@ -267,9 +266,8 @@ class VersionFormatParser {
 						}
 					}
 				} else {
-					if (fragment instanceof StringFragment) {
+					if (fragment instanceof StringFragment stringFrag) {
 						// Check for translations if we default to for MINS or MAXS
-						StringFragment stringFrag = (StringFragment) fragment;
 						Comparable<?> opposite = stringFrag.getOppositeDefaultValue();
 						if (opposite != null) {
 							idx = segments.size() - 1;
@@ -1166,8 +1164,7 @@ class VersionFormatParser {
 		}
 
 		public boolean isOppositeTranslation(Object val) {
-			if (val instanceof String) {
-				String str = (String) val;
+			if (val instanceof String str) {
 				int idx = oppositeTranslationRepeat;
 				if (str.length() == idx) {
 					while (--idx >= 0) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionVector.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/VersionVector.java
@@ -292,11 +292,10 @@ public class VersionVector implements Comparable<VersionVector>, Serializable {
 			return true;
 		}
 
-		if (!(o instanceof VersionVector)) {
+		if (!(o instanceof VersionVector ov)) {
 			return false;
 		}
 
-		VersionVector ov = (VersionVector) o;
 		return equals(vector, padValue, ov.vector, ov.padValue);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/At.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/At.java
@@ -32,8 +32,7 @@ class At extends Binary {
 	@Override
 	public Object evaluate(org.eclipse.equinox.p2.metadata.expression.IEvaluationContext context) {
 		Object lval;
-		if (lhs instanceof DynamicMember) {
-			DynamicMember lm = (DynamicMember) lhs;
+		if (lhs instanceof DynamicMember lm) {
 			Object instance = lm.operand.evaluate(context);
 			if (instance instanceof IInstallableUnit) {
 				String name = lm.getName();

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Binary.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Binary.java
@@ -84,8 +84,7 @@ public abstract class Binary extends Expression {
 	 * LDAP filter binary expression
 	 */
 	void appendLDAPAttribute(StringBuilder buf) {
-		if (lhs instanceof DynamicMember) {
-			DynamicMember attr = (DynamicMember) lhs;
+		if (lhs instanceof DynamicMember attr) {
 			if (attr.operand instanceof Variable) {
 				buf.append(attr.getName());
 				return;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Expression.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Expression.java
@@ -382,8 +382,7 @@ public abstract class Expression implements IExpression, Comparable<Expression>,
 				return false;
 			}
 
-			if (expression instanceof Member) {
-				Member member = (Member) expression;
+			if (expression instanceof Member member) {
 				if (member.getOperand() == operand) {
 					String name = member.getName();
 					if (members == null) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/ExpressionFactory.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/ExpressionFactory.java
@@ -299,12 +299,10 @@ public class ExpressionFactory implements IExpressionFactory, IExpressionConstan
 
 	@Override
 	public IExpression not(IExpression operand) {
-		if (operand instanceof Equals) {
-			Equals eq = (Equals) operand;
+		if (operand instanceof Equals eq) {
 			return new Equals(eq.lhs, eq.rhs, !eq.negate);
 		}
-		if (operand instanceof Compare) {
-			Compare cmp = (Compare) operand;
+		if (operand instanceof Compare cmp) {
 			return new Compare(cmp.lhs, cmp.rhs, !cmp.compareLess, !cmp.equalOK);
 		}
 		if (operand instanceof Not) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Latest.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Latest.java
@@ -31,10 +31,9 @@ final class Latest extends UnaryCollectionFilter {
 	@Override
 	public Iterator<?> evaluateAsIterator(IEvaluationContext context) {
 		HashMap<String, IVersionedId> greatestIUVersion;
-		if (operand instanceof Select) {
+		if (operand instanceof Select select) {
 			// Inline element evaluation here so that we don't build a map that is
 			// larger then it has to be
-			Select select = (Select) operand;
 			Iterator<?> iterator = select.operand.evaluateAsIterator(context);
 			if (!iterator.hasNext()) {
 				return Collections.EMPTY_SET.iterator();
@@ -77,11 +76,10 @@ final class Latest extends UnaryCollectionFilter {
 			greatestIUVersion = new HashMap<>();
 			while (iterator.hasNext()) {
 				Object next = iterator.next();
-				if (!(next instanceof IVersionedId)) {
+				if (!(next instanceof IVersionedId versionedID)) {
 					continue;
 				}
 
-				IVersionedId versionedID = (IVersionedId) next;
 				String id = versionedID.getId();
 
 				IVersionedId prev = greatestIUVersion.put(id, versionedID);

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Matches.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Matches.java
@@ -79,13 +79,11 @@ public class Matches extends Binary {
 			return false;
 		}
 
-		if (rval instanceof IRequirement) {
-			IRequirement requirement = (IRequirement) rval;
+		if (rval instanceof IRequirement requirement) {
 			if (lval instanceof IInstallableUnit) {
 				return Boolean.valueOf(((IInstallableUnit) lval).satisfies(requirement));
 			}
-		} else if (rval instanceof VersionRange) {
-			VersionRange range = (VersionRange) rval;
+		} else if (rval instanceof VersionRange range) {
 			if (lval instanceof Version) {
 				return Boolean.valueOf(range.isIncluded((Version) lval));
 			}
@@ -134,8 +132,7 @@ public class Matches extends Binary {
 			if (lval instanceof Character || lval instanceof Number || lval instanceof Boolean) {
 				return ((LDAPApproximation) rval).isMatch(lval.toString());
 			}
-		} else if (rval instanceof Class<?>) {
-			Class<?> rclass = (Class<?>) rval;
+		} else if (rval instanceof Class<?> rclass) {
 			return lval instanceof Class<?> ? rclass.isAssignableFrom((Class<?>) lval) : rclass.isInstance(lval);
 		}
 		throw new IllegalArgumentException(

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Pipe.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/Pipe.java
@@ -47,8 +47,7 @@ public class Pipe extends NAry {
 			if (indexProvider != null) {
 				return indexProvider.getManagedProperty(client, memberName, key);
 			}
-			if (client instanceof IInstallableUnit && memberName.equals(InstallableUnit.MEMBER_TRANSLATED_PROPERTIES)) {
-				IInstallableUnit iu = (IInstallableUnit) client;
+			if (client instanceof IInstallableUnit iu && memberName.equals(InstallableUnit.MEMBER_TRANSLATED_PROPERTIES)) {
 				return key instanceof KeyWithLocale ? iu.getProperty(((KeyWithLocale) key).getKey()) : iu.getProperty(key.toString());
 			}
 			return null;
@@ -121,8 +120,7 @@ public class Pipe extends NAry {
 	private static Expression makePipeableOfBooleans(IExpressionFactory factory, ArrayList<Expression> booleans) {
 		Expression boolExpr = normalizeBoolean(factory, booleans);
 		Object[] params = null;
-		if (boolExpr instanceof MatchExpression<?>) {
-			MatchExpression<?> matchExpr = (MatchExpression<?>) boolExpr;
+		if (boolExpr instanceof MatchExpression<?> matchExpr) {
 			boolExpr = (Expression) matchExpr.getPredicate();
 			params = matchExpr.getParameters();
 			if (params.length == 0) {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/UnaryCollectionFilter.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/expression/UnaryCollectionFilter.java
@@ -33,8 +33,7 @@ abstract class UnaryCollectionFilter extends Unary {
 
 	@Override
 	public void toString(StringBuilder bld, Variable rootVariable) {
-		if (operand instanceof Select) {
-			Select select = (Select) operand;
+		if (operand instanceof Select select) {
 			CollectionFilter.appendProlog(bld, rootVariable, select.operand, getOperator());
 			appendOperand(bld, rootVariable, select.lambda, getPriority());
 		} else {

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/index/Index.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/internal/p2/metadata/index/Index.java
@@ -22,8 +22,7 @@ import org.eclipse.equinox.p2.metadata.index.IIndex;
 public abstract class Index<T> implements IIndex<T> {
 
 	protected static boolean isIndexedMember(IExpression expr, IExpression variable, String memberName) {
-		if (expr instanceof Member) {
-			Member member = (Member) expr;
+		if (expr instanceof Member member) {
 			return member.getOperand() == variable && member.getName().equals(memberName);
 		}
 		return false;

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/VersionedId.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/metadata/VersionedId.java
@@ -95,11 +95,10 @@ public class VersionedId implements IVersionedId {
 			return true;
 		}
 
-		if (!(obj instanceof VersionedId)) {
+		if (!(obj instanceof VersionedId vname)) {
 			return false;
 		}
 
-		VersionedId vname = (VersionedId) obj;
 		return id.equals(vname.id) && version.equals(vname.version);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/ExpressionQuery.java
+++ b/bundles/org.eclipse.equinox.p2.metadata/src/org/eclipse/equinox/p2/query/ExpressionQuery.java
@@ -83,12 +83,10 @@ public class ExpressionQuery<T> implements IQueryWithIndex<T> {
 			}
 			parameters = new Object[0];
 		} else {
-			if (expr instanceof MatchExpression<?>) {
-				MatchExpression<?> matchExpr = (MatchExpression<?>) expr;
+			if (expr instanceof MatchExpression<?> matchExpr) {
 				parameters = matchExpr.getParameters();
 				expr = factory.select(ExpressionFactory.EVERYTHING, factory.lambda(ExpressionFactory.THIS, matchExpr.operand));
-			} else if (expr instanceof ContextExpression<?>) {
-				ContextExpression<?> contextExpr = (ContextExpression<?>) expr;
+			} else if (expr instanceof ContextExpression<?> contextExpr) {
 				parameters = contextExpr.getParameters();
 				expr = contextExpr.operand;
 			} else {


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

