### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.operations

### DIFF
--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/PlanAnalyzer.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/PlanAnalyzer.java
@@ -93,8 +93,9 @@ public class PlanAnalyzer {
 		}
 
 		// If the overall plan had a non-OK status, capture that in the report.
-		if (!plan.getStatus().isOK())
+		if (!plan.getStatus().isOK()) {
 			report.addSummaryStatus(plan.getStatus());
+		}
 
 		// Now we compare what was requested with what is going to happen.
 		// In the long run, when a RequestStatus can provide actual explanation/status
@@ -105,8 +106,9 @@ public class PlanAnalyzer {
 
 		PlannerStatus plannerStatus = plan.getStatus() instanceof PlannerStatus ? (PlannerStatus) plan.getStatus() : null;
 		// If there is no additional plannerStatus details just return the report
-		if (plannerStatus == null)
+		if (plannerStatus == null) {
 			return report;
+		}
 
 		if (plan.getStatus().getSeverity() != IStatus.ERROR) {
 			Collection<IInstallableUnit> iusAdded = originalRequest.getAdditions();
@@ -162,12 +164,14 @@ public class PlanAnalyzer {
 	}
 
 	private static String getIUString(IInstallableUnit iu) {
-		if (iu == null)
+		if (iu == null) {
 			return Messages.PlanAnalyzer_Items;
+		}
 		// Get the iu name in the default locale
 		String name = iu.getProperty(IInstallableUnit.PROP_NAME, null);
-		if (name != null)
+		if (name != null) {
 			return name;
+		}
 		return iu.getId();
 	}
 

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/PlannerResolutionJob.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/PlannerResolutionJob.java
@@ -43,10 +43,11 @@ public class PlannerResolutionJob extends ProvisioningJob implements IProfileCha
 		super(label, session);
 		this.request = request;
 		this.profileId = profileId;
-		if (context == null)
+		if (context == null) {
 			firstPass = new ProvisioningContext(session.getProvisioningAgent());
-		else
+		} else {
 			firstPass = context;
+		}
 		this.evaluator = evaluator;
 		Assert.isNotNull(additionalStatus);
 		this.additionalStatus = additionalStatus;
@@ -93,8 +94,9 @@ public class PlannerResolutionJob extends ProvisioningJob implements IProfileCha
 
 		// First resolution was in error, try again with an alternate provisioning context
 		ProvisioningContext secondPass = evaluator.getSecondPassProvisioningContext(plan);
-		if (secondPass == null)
+		if (secondPass == null) {
 			return status;
+		}
 
 		successful = secondPass;
 		plan = getSession().getProvisioningAgent().getService(IPlanner.class).getProvisioningPlan(request, secondPass,

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/RemediationResolutionJob.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/RemediationResolutionJob.java
@@ -39,15 +39,17 @@ public class RemediationResolutionJob extends PlannerResolutionJob {
 		SubMonitor sub = SubMonitor.convert(monitor, 2);
 		try {
 			computeRemediationRunnable.run(sub.newChild(1));
-			if (requestHolder.length > 0)
+			if (requestHolder.length > 0) {
 				this.request = requestHolder[0];
+			}
 		} catch (OperationCanceledException e) {
 			return Status.CANCEL_STATUS;
 		} catch (InvocationTargetException e) {
 			// ignore, we don't actually throw this in the supplied runnable
 		}
-		if (request != null)
+		if (request != null) {
 			return super.runModal(sub.newChild(1));
+		}
 		return operation.getResolutionResult();
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/RequestFlexer.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/RequestFlexer.java
@@ -91,45 +91,57 @@ public class RequestFlexer {
 			return null;
 		}
 		IProvisioningPlan intermediaryPlan = resolve(loosenedRequest, sub.newChild(1));
-		if (!intermediaryPlan.getStatus().isOK())
+		if (!intermediaryPlan.getStatus().isOK()) {
 			return null;
-		if (intermediaryPlan.getAdditions().query(QueryUtil.ALL_UNITS, new NullProgressMonitor()).isEmpty() && intermediaryPlan.getRemovals().query(QueryUtil.ALL_UNITS, new NullProgressMonitor()).isEmpty())
+		}
+		if (intermediaryPlan.getAdditions().query(QueryUtil.ALL_UNITS, new NullProgressMonitor()).isEmpty() && intermediaryPlan.getRemovals().query(QueryUtil.ALL_UNITS, new NullProgressMonitor()).isEmpty()) {
 			//No changes, we can't return anything
 			return null;
+		}
 		if (!productContainmentOK(intermediaryPlan)) {
 			return null;
 		}
 		IProfileChangeRequest effectiveRequest = computeEffectiveChangeRequest(intermediaryPlan, loosenedRequest, request);
-		if (isRequestUseless(effectiveRequest))
+		if (isRequestUseless(effectiveRequest)) {
 			return null;
+		}
 		return effectiveRequest;
 	}
 
 	private boolean isRequestUseless(IProfileChangeRequest effectiveRequest) {
-		if (effectiveRequest.getAdditions().isEmpty() && effectiveRequest.getRemovals().isEmpty())
+		if (effectiveRequest.getAdditions().isEmpty() && effectiveRequest.getRemovals().isEmpty()) {
 			return true;
-		if (effectiveRequest.getRemovals().containsAll(effectiveRequest.getAdditions()))
+		}
+		if (effectiveRequest.getRemovals().containsAll(effectiveRequest.getAdditions())) {
 			return true;
+		}
 		return false;
 	}
 
 	private boolean canShortCircuit(IProfileChangeRequest originalRequest) {
 		//Case where the user is asking to install only some of the requested IUs but there is only one IU to install. 
-		if (allowPartialInstall && !allowInstalledUpdate && !allowDifferentVersion && !allowInstalledRemoval)
-			if (originalRequest.getAdditions().size() == 1)
+		if (allowPartialInstall && !allowInstalledUpdate && !allowDifferentVersion && !allowInstalledRemoval) {
+			if (originalRequest.getAdditions().size() == 1) {
 				return true;
+			}
+		}
 
 		//When we can find a different version of the IU but the only version available is the one the user is asking to install
-		if (allowDifferentVersion && !allowPartialInstall && !allowInstalledRemoval && !allowInstalledUpdate)
-			if (!foundDifferentVersionsForElementsToInstall)
+		if (allowDifferentVersion && !allowPartialInstall && !allowInstalledRemoval && !allowInstalledUpdate) {
+			if (!foundDifferentVersionsForElementsToInstall) {
 				return true;
+			}
+		}
 
-		if (allowInstalledUpdate && !allowDifferentVersion && !allowPartialInstall && !allowInstalledRemoval)
-			if (!foundDifferentVersionsForElementsInstalled)
+		if (allowInstalledUpdate && !allowDifferentVersion && !allowPartialInstall && !allowInstalledRemoval) {
+			if (!foundDifferentVersionsForElementsInstalled) {
 				return true;
+			}
+		}
 
-		if (!allowPartialInstall && !allowInstalledUpdate && !allowDifferentVersion && !allowInstalledRemoval)
+		if (!allowPartialInstall && !allowInstalledUpdate && !allowDifferentVersion && !allowInstalledRemoval) {
 			return true;
+		}
 
 		return false;
 	}
@@ -158,14 +170,16 @@ public class RequestFlexer {
 			IQuery<IInstallableUnit> query = QueryUtil.createMatchQuery(alreadyInstalled.getMatches());
 			IQueryResult<IInstallableUnit> matches = intermediaryPlan.getFutureState().query(QueryUtil.createLatestQuery(query), null);
 			IInstallableUnit potentialRootChange = null;
-			if (!matches.isEmpty())
+			if (!matches.isEmpty()) {
 				potentialRootChange = matches.iterator().next();
+			}
 
 			IQueryResult<IInstallableUnit> iuAlreadyInstalled = profile.available(query, new NullProgressMonitor());
 
 			if (!iuAlreadyInstalled.isEmpty()) {//This deals with the case where the root has not changed
-				if (potentialRootChange != null && iuAlreadyInstalled.toUnmodifiableSet().contains(potentialRootChange))
+				if (potentialRootChange != null && iuAlreadyInstalled.toUnmodifiableSet().contains(potentialRootChange)) {
 					continue;
+				}
 			}
 			iusToRemove.addAll(iuAlreadyInstalled.toUnmodifiableSet());
 			if (potentialRootChange != null) {
@@ -188,8 +202,9 @@ public class RequestFlexer {
 		//Finish construction of the IPCR
 		finalChangeRequest.addAll(iusToAdd);
 		finalChangeRequest.removeAll(iusToRemove);
-		if (originalRequest.getExtraRequirements() != null)
+		if (originalRequest.getExtraRequirements() != null) {
 			finalChangeRequest.addExtraRequirements(originalRequest.getExtraRequirements());
+		}
 		return finalChangeRequest;
 	}
 
@@ -235,10 +250,11 @@ public class RequestFlexer {
 			return planner.getProvisioningPlan(temporaryRequest, provisioningContext, subMonitor.split(1));
 		} finally {
 			if (provisioningContext != null) {
-				if (explainPropertyBackup == null)
+				if (explainPropertyBackup == null) {
 					provisioningContext.getProperties().remove(EXPLANATION_ENABLEMENT);
-				else
+				} else {
 					provisioningContext.setProperty(EXPLANATION_ENABLEMENT, explainPropertyBackup);
+				}
 			}
 		}
 	}
@@ -267,8 +283,9 @@ public class RequestFlexer {
 		newRequest.removeAll(originalRequest.getRemovals());
 
 		//Deal with extra requirements that could have been specified
-		if (originalRequest.getExtraRequirements() != null)
+		if (originalRequest.getExtraRequirements() != null) {
 			newRequest.addExtraRequirements(originalRequest.getExtraRequirements());
+		}
 	}
 
 	//This keeps track for each requirement created (those created to loosen the constraint), of the original IU and the properties associated with it in the profile
@@ -287,20 +304,23 @@ public class RequestFlexer {
 		}
 
 		Map<String, String> propertiesInRequest = ((ProfileChangeRequest) originalRequest).getInstallableUnitProfilePropertiesToAdd().get(iu);
-		if (propertiesInRequest != null)
+		if (propertiesInRequest != null) {
 			allProperties.putAll(propertiesInRequest);
+		}
 
 		propertiesPerRequirement.put(req, allProperties);
 
 		List<String> removalInRequest = ((ProfileChangeRequest) originalRequest).getInstallableUnitProfilePropertiesToRemove().get(iu);
-		if (removalInRequest != null)
+		if (removalInRequest != null) {
 			removedPropertiesPerRequirement.put(req, removalInRequest);
+		}
 	}
 
 	private boolean isRequestedInstallationOptional(IInstallableUnit iu, IProfileChangeRequest originalRequest) {
 		Map<String, String> match = ((ProfileChangeRequest) originalRequest).getInstallableUnitProfilePropertiesToAdd().get(iu);
-		if (match == null)
+		if (match == null) {
 			return false;
+		}
 		return INCLUSION_OPTIONAL.equals(match.get(INCLUSION_RULES));
 	}
 
@@ -335,8 +355,9 @@ public class RequestFlexer {
 		int count = 0;
 		for (IInstallableUnit iu : findUpdates) {
 			expression.append("(id == $").append(count * 2).append(" && version == $").append(count * 2 + 1).append(')'); //$NON-NLS-1$//$NON-NLS-2$
-			if (findUpdates.size() > 1 && count < findUpdates.size() - 1)
+			if (findUpdates.size() > 1 && count < findUpdates.size() - 1) {
 				expression.append(" || "); //$NON-NLS-1$
+			}
 			expressionParameters[count * 2] = iu.getId();
 			expressionParameters[count * 2 + 1] = iu.getVersion();
 			count++;
@@ -348,8 +369,9 @@ public class RequestFlexer {
 	//Loosen up the IUs that are already part of the profile
 	//Given how we are creating our request, this needs to take into account the removal from the original request as well as the change in inclusion 
 	private IProfileChangeRequest loosenUpInstalledSoftware(IProfileChangeRequest request, IProfileChangeRequest originalRequest, IProgressMonitor monitor) {
-		if (!allowInstalledRemoval && !allowInstalledUpdate)
+		if (!allowInstalledRemoval && !allowInstalledUpdate) {
 			return request;
+		}
 		Set<IInstallableUnit> allRoots = getRoots();
 
 		for (IInstallableUnit existingIU : allRoots) {
@@ -371,8 +393,9 @@ public class RequestFlexer {
 
 	private Set<IInstallableUnit> getRoots() {
 		Set<IInstallableUnit> allRoots = profile.query(new IUProfilePropertyQuery(INCLUSION_RULES, IUProfilePropertyQuery.ANY), null).toSet();
-		if (!honorSharedSettings)
+		if (!honorSharedSettings) {
 			return allRoots;
+		}
 		IQueryResult<IInstallableUnit> baseRoots = profile.query(new IUProfilePropertyQuery("org.eclipse.equinox.p2.base", Boolean.TRUE.toString()), null); //$NON-NLS-1$
 		allRoots.removeAll(baseRoots.toUnmodifiableSet());
 		return allRoots;
@@ -386,8 +409,9 @@ public class RequestFlexer {
 
 	//Given the change request, this returns the collection of optional IUs 
 	private Set<IInstallableUnit> computeFutureStateOfInclusion(ProfileChangeRequest profileChangeRequest) {
-		if (futureOptionalIUs != null)
+		if (futureOptionalIUs != null) {
 			return futureOptionalIUs;
+		}
 
 		futureOptionalIUs = profileChangeRequest.getProfile().query(new IUProfilePropertyQuery(INCLUSION_RULES, INCLUSION_OPTIONAL), null).toSet();
 
@@ -415,16 +439,20 @@ public class RequestFlexer {
 	}
 
 	private boolean productContainmentOK(IProvisioningPlan intermediaryPlan) {
-		if (!ensureProductPresence)
+		if (!ensureProductPresence) {
 			return true;
-		if (!hasProduct())
+		}
+		if (!hasProduct()) {
 			return true;
+		}
 		//At this point we know we had a product installed and we want to make sure there is one in the resulting solution
-		if (!intermediaryPlan.getFutureState().query(QueryUtil.createIUProductQuery(), new NullProgressMonitor()).isEmpty())
+		if (!intermediaryPlan.getFutureState().query(QueryUtil.createIUProductQuery(), new NullProgressMonitor()).isEmpty()) {
 			return true;
+		}
 		//Support for legacy identification of product using the lineUp.
-		if (!intermediaryPlan.getFutureState().query(QueryUtil.createIUPropertyQuery("lineUp", "true"), new NullProgressMonitor()).isEmpty()) //$NON-NLS-1$//$NON-NLS-2$
+		if (!intermediaryPlan.getFutureState().query(QueryUtil.createIUPropertyQuery("lineUp", "true"), new NullProgressMonitor()).isEmpty()) { //$NON-NLS-1$//$NON-NLS-2$
 			return true;
+		}
 		return false;
 	}
 
@@ -433,8 +461,9 @@ public class RequestFlexer {
 			return true;
 		}
 		//Support for legacy identification of product using the lineUp.
-		if (!profile.available(QueryUtil.createIUPropertyQuery("lineUp", "true"), new NullProgressMonitor()).isEmpty()) //$NON-NLS-1$//$NON-NLS-2$
+		if (!profile.available(QueryUtil.createIUPropertyQuery("lineUp", "true"), new NullProgressMonitor()).isEmpty()) { //$NON-NLS-1$//$NON-NLS-2$
 			return true;
+		}
 		return false;
 	}
 

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/ResolutionResult.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/ResolutionResult.java
@@ -31,8 +31,9 @@ public class ResolutionResult {
 	private MultiStatus summaryStatus;
 
 	public IStatus getSummaryStatus() {
-		if (summaryStatus != null)
+		if (summaryStatus != null) {
 			return summaryStatus;
+		}
 		return Status.OK_STATUS;
 	}
 
@@ -55,17 +56,20 @@ public class ResolutionResult {
 		MultiStatus iuSummaryStatus = iuToStatusMap.get(iu);
 		if (iuSummaryStatus == null) {
 			iuSummaryStatus = new MultiStatus(Constants.BUNDLE_ID, IStatusCodes.IU_REQUEST_ALTERED, new IStatus[] {status}, getIUString(iu), null);
-		} else
+		} else {
 			iuSummaryStatus.add(status);
+		}
 	}
 
 	private String getIUString(IInstallableUnit iu) {
-		if (iu == null)
+		if (iu == null) {
 			return Messages.PlanAnalyzer_Items;
+		}
 		// Get the iu name in the default locale
 		String name = iu.getProperty(IInstallableUnit.PROP_NAME, null);
-		if (name != null)
+		if (name != null) {
 			return name;
+		}
 		return iu.getId();
 	}
 
@@ -83,49 +87,57 @@ public class ResolutionResult {
 		StringBuilder buffer = new StringBuilder();
 		for (IInstallableUnit iu : ius) {
 			MultiStatus iuStatus = iuToStatusMap.get(iu);
-			if (iuStatus != null)
+			if (iuStatus != null) {
 				appendDetailText(iuStatus, buffer, 0, true);
+			}
 		}
 		String report = buffer.toString();
-		if (report.length() == 0)
+		if (report.length() == 0) {
 			return null;
+		}
 		return report;
 	}
 
 	void appendDetailText(IStatus status, StringBuilder buffer, int indent, boolean includeTopLevelMessage) {
 		if (includeTopLevelMessage) {
-			for (int i = 0; i < indent; i++)
+			for (int i = 0; i < indent; i++) {
 				buffer.append(NESTING_INDENT);
-			if (status.getMessage() != null)
+			}
+			if (status.getMessage() != null) {
 				buffer.append(status.getMessage());
+			}
 		}
 		Throwable t = status.getException();
 		if (t != null) {
 			// A provision (or core) exception occurred.  Get its status message or if none, its top level message.
 			// Indent by one more level (note the <=)
 			buffer.append('\n');
-			for (int i = 0; i <= indent; i++)
+			for (int i = 0; i <= indent; i++) {
 				buffer.append(NESTING_INDENT);
+			}
 			if (t instanceof CoreException) {
 				IStatus exceptionStatus = ((CoreException) t).getStatus();
-				if (exceptionStatus != null && exceptionStatus.getMessage() != null)
+				if (exceptionStatus != null && exceptionStatus.getMessage() != null) {
 					buffer.append(exceptionStatus.getMessage());
-				else {
+				} else {
 					String details = t.getLocalizedMessage();
-					if (details != null)
+					if (details != null) {
 						buffer.append(details);
+					}
 				}
 			} else {
 				String details = t.getLocalizedMessage();
-				if (details != null)
+				if (details != null) {
 					buffer.append(details);
+				}
 			}
 		}
 		// Now print the children status info (if there are children)
 		IStatus[] children = status.getChildren();
 		for (IStatus child : children) {
-			if (buffer.length() > 0)
+			if (buffer.length() > 0) {
 				buffer.append('\n');
+			}
 			appendDetailText(child, buffer, indent + 1, true);
 		}
 	}

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/SearchForUpdatesResolutionJob.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/internal/p2/operations/SearchForUpdatesResolutionJob.java
@@ -39,15 +39,17 @@ public class SearchForUpdatesResolutionJob extends PlannerResolutionJob {
 		SubMonitor sub = SubMonitor.convert(monitor);
 		try {
 			searchForUpdatesRunnable.run(sub.newChild(500));
-			if (requestHolder.length > 0)
+			if (requestHolder.length > 0) {
 				this.request = requestHolder[0];
+			}
 		} catch (OperationCanceledException e) {
 			return Status.CANCEL_STATUS;
 		} catch (InvocationTargetException e) {
 			// ignore, we don't actually throw this in the supplied runnable
 		}
-		if (request != null)
+		if (request != null) {
 			return super.runModal(sub.newChild(500));
+		}
 		return operation.getResolutionResult();
 	}
 

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/InstallOperation.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/InstallOperation.java
@@ -77,8 +77,9 @@ public class InstallOperation extends ProfileChangeOperation {
 		for (IInstallableUnit entryToInstall : toInstall) {
 			// If the user is installing a patch, we mark it optional.  This allows
 			// the patched IU to be updated later by removing the patch.
-			if (QueryUtil.isPatch(entryToInstall))
+			if (QueryUtil.isPatch(entryToInstall)) {
 				request.setInstallableUnitInclusionRules(entryToInstall, ProfileInclusionRules.createOptionalInclusionRule(entryToInstall));
+			}
 
 			// Check to see if it is already installed.  This may alter the request.
 			IQueryResult<IInstallableUnit> alreadyInstalled = profile.query(QueryUtil.createIUQuery(entryToInstall.getId()), null);
@@ -92,8 +93,9 @@ public class InstallOperation extends ProfileChangeOperation {
 				if (compareTo > 0) {
 					boolean lockedForUpdate = false;
 					String value = profile.getInstallableUnitProperty(installedIU, IProfile.PROP_PROFILE_LOCKED_IU);
-					if (value != null)
+					if (value != null) {
 						lockedForUpdate = (Integer.parseInt(value) & IProfile.LOCK_UPDATE) == IProfile.LOCK_UPDATE;
+					}
 					if (lockedForUpdate) {
 						// Add a status telling the user that this implies an update, but the iu should not be updated
 						status.merge(PlanAnalyzer.getStatus(IStatusCodes.ALTERED_IGNORED_IMPLIED_UPDATE, entryToInstall));
@@ -104,10 +106,10 @@ public class InstallOperation extends ProfileChangeOperation {
 					// An implied downgrade.  We will not put this in the plan, add a status informing the user
 					status.merge(PlanAnalyzer.getStatus(IStatusCodes.ALTERED_IGNORED_IMPLIED_DOWNGRADE, entryToInstall));
 				} else {
-					if (UserVisibleRootQuery.isUserVisible(installedIU, profile))
+					if (UserVisibleRootQuery.isUserVisible(installedIU, profile)) {
 						// It is already a root, nothing to do. We tell the user it was already installed
 						status.merge(PlanAnalyzer.getStatus(IStatusCodes.ALTERED_IGNORED_ALREADY_INSTALLED, entryToInstall));
-					else {
+					} else {
 						// It was already installed but not as a root.  Tell the user that parts of it are already installed and mark
 						// it as a root. 
 						status.merge(PlanAnalyzer.getStatus(IStatusCodes.ALTERED_PARTIAL_INSTALL, entryToInstall));
@@ -126,9 +128,10 @@ public class InstallOperation extends ProfileChangeOperation {
 						break;
 					}
 				}
-				if (!handled)
+				if (!handled) {
 					// Install it and mark as a root
 					request.add(entryToInstall);
+				}
 				request.setInstallableUnitProfileProperty(entryToInstall, IProfile.PROP_PROFILE_ROOT_IU, Boolean.toString(true));
 			}
 			sub.worked(1);
@@ -142,8 +145,9 @@ public class InstallOperation extends ProfileChangeOperation {
 		// Add a status informing the user that the update has been inferred
 		status.merge(PlanAnalyzer.getStatus(IStatusCodes.ALTERED_IMPLIED_UPDATE, entryToInstall));
 		// Mark it as a root if it hasn't been already
-		if (!UserVisibleRootQuery.isUserVisible(installedIU, profile))
+		if (!UserVisibleRootQuery.isUserVisible(installedIU, profile)) {
 			request.setInstallableUnitProfileProperty(entryToInstall, IProfile.PROP_PROFILE_ROOT_IU, Boolean.toString(true));
+		}
 	}
 
 	@Override
@@ -169,8 +173,9 @@ public class InstallOperation extends ProfileChangeOperation {
 		return failedPlan -> {
 			// Follow metadata repository references if the first try fails
 			// There should be real API for this!
-			if (missingRequirement(failedPlan))
+			if (missingRequirement(failedPlan)) {
 				context.setProperty(ProvisioningContext.FOLLOW_REPOSITORY_REFERENCES, Boolean.toString(true));
+			}
 			return context;
 		};
 	}
@@ -179,8 +184,9 @@ public class InstallOperation extends ProfileChangeOperation {
 	boolean missingRequirement(IProvisioningPlan failedPlan) {
 		IStatus status = failedPlan.getStatus();
 		RequestStatus requestStatus = null;
-		if (status instanceof PlannerStatus)
+		if (status instanceof PlannerStatus) {
 			requestStatus = ((PlannerStatus) status).getRequestStatus();
+		}
 		return requestStatus != null && requestStatus.getShortExplanation() == Explanation.MISSING_REQUIREMENT;
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/OperationFactory.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/OperationFactory.java
@@ -45,8 +45,9 @@ public class OperationFactory {
 		} catch (InvalidSyntaxException e) {
 			//ignore can't happen since we write the filter ourselves
 		}
-		if (ref == null || ref.size() == 0)
+		if (ref == null || ref.size() == 0) {
 			throw new IllegalStateException(Messages.OperationFactory_noAgent);
+		}
 		IProvisioningAgent agent = bundleContext.getService(ref.iterator().next());
 		bundleContext.ungetService(ref.iterator().next());
 		return agent;
@@ -64,8 +65,9 @@ public class OperationFactory {
 
 			IQuery<IInstallableUnit> installableUnits = QueryUtil.createIUQuery(versionedId.getId(), versionedId.getVersion());
 			IQueryResult<IInstallableUnit> matches = searchContext.query(installableUnits, monitor);
-			if (matches.isEmpty())
+			if (matches.isEmpty()) {
 				throw new ProvisionException(new Status(IStatus.ERROR, Constants.BUNDLE_ID, NLS.bind(Messages.OperationFactory_noIUFound, versionedId)));
+			}
 
 			//Add the first IU
 			Iterator<IInstallableUnit> iuIt = matches.iterator();
@@ -136,10 +138,12 @@ public class OperationFactory {
 	public IQueryResult<IInstallableUnit> listInstalledElements(boolean rootsOnly, IProgressMonitor monitor) {
 		IProfileRegistry registry = getAgent().getService(IProfileRegistry.class);
 		IProfile profile = registry.getProfile(IProfileRegistry.SELF);
-		if (profile == null)
+		if (profile == null) {
 			return new CollectionResult<>(null);
-		if (rootsOnly)
+		}
+		if (rootsOnly) {
 			return profile.query(new UserVisibleRootQuery(), monitor);
+		}
 		return profile.query(QueryUtil.ALL_UNITS, monitor);
 	}
 
@@ -175,10 +179,11 @@ public class OperationFactory {
 		ProvisioningContext ctx = createProvisioningContext(repos, agent);
 
 		Collection<IInstallableUnit> iusToInstall;
-		if (toInstall == null)
+		if (toInstall == null) {
 			iusToInstall = ctx.getMetadata(monitor).query(QueryUtil.createIUGroupQuery(), monitor).toUnmodifiableSet();
-		else
+		} else {
 			iusToInstall = gatherIUs(ctx.getMetadata(monitor), toInstall, false, monitor);
+		}
 
 		SynchronizeOperation resultingOperation = new SynchronizeOperation(new ProvisioningSession(agent), iusToInstall);
 		resultingOperation.setProvisioningContext(ctx);

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProfileChangeOperation.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProfileChangeOperation.java
@@ -115,8 +115,9 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 		makeResolveJob(subMon.split(1));
 		if (job != null) {
 			IStatus status = job.runModal(subMon.split(1));
-			if (status.getSeverity() == IStatus.CANCEL)
+			if (status.getSeverity() == IStatus.CANCEL) {
 				return Status.CANCEL_STATUS;
+			}
 		}
 		monitor.done();
 		// For anything other than cancellation, we examine the artifacts of the resolution and come
@@ -146,10 +147,12 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 		SubMonitor mon = SubMonitor.convert(monitor, Messages.ProfileChangeOperation_ResolveTaskName, 1000);
 		prepareToResolve();
 		makeResolveJob(mon.newChild(100));
-		if (mon.isCanceled())
+		if (mon.isCanceled()) {
 			return null;
-		if (job != null)
+		}
+		if (job != null) {
 			job.setAdditionalProgressMonitor(mon.newChild(900));
+		}
 		return job;
 	}
 
@@ -168,9 +171,10 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 			computeProfileChangeRequest(noChangeRequest, monitor);
 		}
 		if (request == null) {
-			if (noChangeRequest.getChildren().length == 0)
+			if (noChangeRequest.getChildren().length == 0) {
 				// No explanation for failure was provided.  It shouldn't happen, but...
 				noChangeRequest = new MultiStatus(Constants.BUNDLE_ID, IStatusCodes.UNEXPECTED_NOTHING_TO_DO, new IStatus[] {PlanAnalyzer.getStatus(IStatusCodes.UNEXPECTED_NOTHING_TO_DO, null)}, Messages.ProfileChangeOperation_NoProfileChangeRequest, null);
+			}
 			return;
 		}
 		createPlannerResolutionJob();
@@ -217,14 +221,16 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 		if (request == null) {
 			if (noChangeRequest != null) {
 				// If there is only one child message, use the specific message
-				if (noChangeRequest.getChildren().length == 1)
+				if (noChangeRequest.getChildren().length == 1) {
 					return noChangeRequest.getChildren()[0];
+				}
 				return noChangeRequest;
 			}
 			return null;
 		}
-		if (job != null && job.getResolutionResult() != null)
+		if (job != null && job.getResolutionResult() != null) {
 			return job.getResolutionResult().getSummaryStatus();
+		}
 		return null;
 	}
 
@@ -236,13 +242,15 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 * operation has not been resolved.
 	 */
 	public String getResolutionDetails() {
-		if (job != null && job.getResolutionResult() != null)
+		if (job != null && job.getResolutionResult() != null) {
 			return job.getResolutionResult().getSummaryReport();
+		}
 		// We couldn't resolve, but we have some status describing
 		// why there is no profile change request.
 		IStatus result = getResolutionResult();
-		if (result != null)
+		if (result != null) {
 			return result.getMessage();
+		}
 		return null;
 
 	}
@@ -257,8 +265,9 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 * there are no specific results available for the installable unit.
 	 */
 	public String getResolutionDetails(IInstallableUnit iu) {
-		if (job != null && job.getResolutionResult() != null)
+		if (job != null && job.getResolutionResult() != null) {
 			return job.getResolutionResult().getDetailedReport(new IInstallableUnit[] {iu});
+		}
 		return null;
 
 	}
@@ -275,8 +284,9 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 * @see #getResolutionResult()
 	 */
 	public IProvisioningPlan getProvisioningPlan() {
-		if (job != null)
+		if (job != null) {
 			return job.getProvisioningPlan();
+		}
 		return null;
 	}
 
@@ -293,8 +303,9 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 * @since 2.1
 	 */
 	public IProfileChangeRequest getProfileChangeRequest() {
-		if (job != null)
+		if (job != null) {
 			return job.getProfileChangeRequest();
+		}
 		return null;
 	}
 
@@ -321,8 +332,9 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	public ProvisioningJob getProvisioningJob(IProgressMonitor monitor) {
 		IStatus status = getResolutionResult();
 		//if status is null we haven't resolved yet, so we must return null here
-		if (status == null)
+		if (status == null) {
 			return null;
+		}
 		if (status.getSeverity() != IStatus.CANCEL && status.getSeverity() != IStatus.ERROR) {
 			if (job.getProvisioningPlan() != null) {
 				ProfileModificationJob pJob = new ProfileModificationJob(getProvisioningJobName(), session, profileId, job.getProvisioningPlan(), job.getActualProvisioningContext());
@@ -342,8 +354,9 @@ public abstract class ProfileChangeOperation implements IProfileChangeJob {
 	 */
 	public void setProvisioningContext(ProvisioningContext context) {
 		this.context = context;
-		if (job != null)
+		if (job != null) {
 			updateJobProvisioningContexts(job, context);
+		}
 	}
 
 	/**

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProfileModificationJob.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProfileModificationJob.java
@@ -65,12 +65,14 @@ public class ProfileModificationJob extends ProvisioningJob implements IProfileC
 
 	@Override
 	public IStatus runModal(IProgressMonitor monitor) {
-		if (monitor == null)
+		if (monitor == null) {
 			monitor = new NullProgressMonitor();
+		}
 		String task = taskName;
 		IStatus status = Status.OK_STATUS;
-		if (task == null)
+		if (task == null) {
 			task = getName();
+		}
 		try {
 			SubMonitor subMonitor = SubMonitor.convert(monitor, task, 1000);
 			status = getSession().performProvisioningPlan(plan, phaseSet, provisioningContext, subMonitor);
@@ -92,8 +94,9 @@ public class ProfileModificationJob extends ProvisioningJob implements IProfileC
 	@Override
 	public int getRestartPolicy() {
 		//if we are installing into self we must always use the restart policy
-		if (IProfileRegistry.SELF.equals(profileId))
+		if (IProfileRegistry.SELF.equals(profileId)) {
 			return restartPolicy;
+		}
 		//otherwise only apply restart policy if the profile being modified is the one that is currently running
 		IProfile profile = getSession().getProfileRegistry().getProfile(IProfileRegistry.SELF);
 		String id = profile == null ? null : profile.getProfileId();

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProvisioningJob.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProvisioningJob.java
@@ -68,8 +68,9 @@ public abstract class ProvisioningJob extends Job {
 
 		@Override
 		public boolean isCanceled() {
-			if (super.isCanceled())
+			if (super.isCanceled()) {
 				return true;
+			}
 			return additionalMonitor.isCanceled();
 		}
 
@@ -160,10 +161,12 @@ public abstract class ProvisioningJob extends Job {
 	}
 
 	private IProgressMonitor getCombinedProgressMonitor(IProgressMonitor mon1, IProgressMonitor mon2) {
-		if (mon1 == null)
+		if (mon1 == null) {
 			return mon2;
-		if (mon2 == null)
+		}
+		if (mon2 == null) {
 			return mon1;
+		}
 		return new DoubleProgressMonitor(mon1, mon2);
 	}
 
@@ -225,11 +228,13 @@ public abstract class ProvisioningJob extends Job {
 	 * @return a status that can be used to describe the exception
 	 */
 	protected IStatus getErrorStatus(String message, ProvisionException e) {
-		if (message == null)
-			if (e == null)
+		if (message == null) {
+			if (e == null) {
 				message = NLS.bind(Messages.ProvisioningJob_GenericErrorStatusMessage, getName());
-			else
+			} else {
 				message = e.getLocalizedMessage();
+			}
+		}
 		return new Status(IStatus.ERROR, Constants.BUNDLE_ID, message, e);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProvisioningSession.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/ProvisioningSession.java
@@ -179,9 +179,11 @@ public class ProvisioningSession {
 
 	private boolean doesPhaseSetIncludeDownload(IPhaseSet set) {
 		String[] phaseIds = set.getPhaseIds();
-		for (String phaseId : phaseIds)
-			if (phaseId.equals(PhaseSetFactory.PHASE_COLLECT))
+		for (String phaseId : phaseIds) {
+			if (phaseId.equals(PhaseSetFactory.PHASE_COLLECT)) {
 				return true;
+			}
+		}
 		return false;
 	}
 
@@ -199,8 +201,9 @@ public class ProvisioningSession {
 		for (Job job : jobs) {
 			if (job instanceof IProfileChangeJob) {
 				String id = ((IProfileChangeJob) job).getProfileId();
-				if (profileId.equals(id))
+				if (profileId.equals(id)) {
 					return true;
+				}
 			}
 		}
 		return false;

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RemediationOperation.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RemediationOperation.java
@@ -108,8 +108,9 @@ public class RemediationOperation extends ProfileChangeOperation {
 		try {
 			for (int i = 0; i < remedyConfigs.length; i++) {
 				sub.subTask((i + 1) + " / " + remedyConfigs.length); //$NON-NLS-1$
-				if (sub.isCanceled())
+				if (sub.isCanceled()) {
 					return Status.CANCEL_STATUS;
+				}
 				Remedy remedy = computeRemedy(remedyConfigs[i], sub.newChild(1, SubMonitor.SUPPRESS_ALL_LABELS));
 				if (remedy != null) {
 					tmpRemedies.add(remedy);
@@ -152,8 +153,9 @@ public class RemediationOperation extends ProfileChangeOperation {
 		av.setAllowPartialInstall(configuration.allowPartialInstall);
 		av.setProvisioningContext(getProvisioningContext());
 		remedy.setRequest((ProfileChangeRequest) av.getChangeRequest(originalRequest, ((ProfileChangeRequest) originalRequest).getProfile(), monitor));
-		if (remedy.getRequest() == null)
+		if (remedy.getRequest() == null) {
 			return null;
+		}
 
 		if (configuration.allowInstalledUpdate && !configuration.allowInstalledRemoval) {
 			remedy.setInstallationRelaxedWeight(HIGH_WEIGHT);
@@ -161,8 +163,9 @@ public class RemediationOperation extends ProfileChangeOperation {
 			remedy.setInstallationRelaxedWeight(MEDIUM_WEIGHT);
 		} else if (configuration.allowInstalledUpdate && configuration.allowInstalledRemoval) {
 			remedy.setInstallationRelaxedWeight(LOW_WEIGHT);
-		} else
+		} else {
 			remedy.setInstallationRelaxedWeight(ZERO_WEIGHT);
+		}
 
 		if (configuration.allowDifferentVersion && !configuration.allowPartialInstall) {
 			remedy.setBeingInstalledRelaxedWeight(HIGH_WEIGHT);
@@ -228,8 +231,9 @@ public class RemediationOperation extends ProfileChangeOperation {
 
 	@Override
 	public IStatus getResolutionResult() {
-		if (currentRemedy != null)
+		if (currentRemedy != null) {
 			return super.getResolutionResult();
+		}
 		return remedies.size() > 0 ? Status.OK_STATUS : new Status(IStatus.ERROR, Constants.BUNDLE_ID, Messages.RemediationOperation_NoRemedyFound);
 	}
 
@@ -302,8 +306,9 @@ public class RemediationOperation extends ProfileChangeOperation {
 
 	private Version searchInOriginalRequest(String id) {
 		for (IInstallableUnit iu : originalRequest.getAdditions()) {
-			if (iu.getId() == id)
+			if (iu.getId() == id) {
 				return iu.getVersion();
+			}
 		}
 		return null;
 	}

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RepositoryTracker.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/RepositoryTracker.java
@@ -82,8 +82,9 @@ public abstract class RepositoryTracker {
 		}
 		// If a path separator char was used, interpret as a local file URI
 		String uriString = URIUtil.toUnencodedString(userLocation);
-		if (uriString.length() > 0 && (uriString.charAt(0) == '/' || uriString.charAt(0) == File.separatorChar))
+		if (uriString.length() > 0 && (uriString.charAt(0) == '/' || uriString.charAt(0) == File.separatorChar)) {
 			return RepositoryHelper.localRepoURIHelper(userLocation);
+		}
 		return userLocation;
 	}
 
@@ -112,8 +113,9 @@ public abstract class RepositoryTracker {
 			}
 		}
 
-		if (!localValidationStatus.isOK())
+		if (!localValidationStatus.isOK()) {
 			return localValidationStatus;
+		}
 
 		return Status.OK_STATUS;
 	}
@@ -238,8 +240,9 @@ public abstract class RepositoryTracker {
 		// special handling when the repo location is bad.  We don't want to continually report it
 		boolean repoLocationIsBad = LoadFailure.failureRepresentsBadRepositoryLocation(exception);
 		if (repoLocationIsBad) {
-			if (hasNotFoundStatusBeenReported(location))
+			if (hasNotFoundStatusBeenReported(location)) {
 				return;
+			}
 			addNotFound(location);
 		}
 

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/SynchronizeOperation.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/SynchronizeOperation.java
@@ -60,10 +60,11 @@ public class SynchronizeOperation extends InstallOperation {
 		request.addAll(toInstall);
 		for (IInstallableUnit entryToInstall : toInstall) {
 			// If the user is installing a patch, we mark it optional.  This allows the patched IU to be updated later by removing the patch.
-			if (QueryUtil.isPatch(entryToInstall))
+			if (QueryUtil.isPatch(entryToInstall)) {
 				request.setInstallableUnitInclusionRules(entryToInstall, ProfileInclusionRules.createOptionalInclusionRule(entryToInstall));
-			else
+			} else {
 				request.setInstallableUnitProfileProperty(entryToInstall, IProfile.PROP_PROFILE_ROOT_IU, Boolean.toString(true));
+			}
 
 			sub.worked(1);
 		}

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/Update.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/Update.java
@@ -39,16 +39,21 @@ public class Update {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (obj == null) {
 			return false;
-		if (!(obj instanceof Update))
+		}
+		if (!(obj instanceof Update)) {
 			return false;
-		if (toUpdate == null)
+		}
+		if (toUpdate == null) {
 			return false;
-		if (replacement == null)
+		}
+		if (replacement == null) {
 			return false;
+		}
 		Update other = (Update) obj;
 		return toUpdate.equals(other.toUpdate) && replacement.equals(other.replacement);
 	}

--- a/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/UpdateOperation.java
+++ b/bundles/org.eclipse.equinox.p2.operations/src/org/eclipse/equinox/p2/operations/UpdateOperation.java
@@ -116,8 +116,9 @@ public class UpdateOperation extends ProfileChangeOperation {
 	 * @return the updates that should be chosen from all of the available updates
 	 */
 	public Update[] getSelectedUpdates() {
-		if (defaultUpdates == null)
+		if (defaultUpdates == null) {
 			return new Update[0];
+		}
 		return defaultUpdates.toArray(new Update[defaultUpdates.size()]);
 	}
 
@@ -129,8 +130,9 @@ public class UpdateOperation extends ProfileChangeOperation {
 	 */
 	public Update[] getPossibleUpdates() {
 		ArrayList<Update> all = new ArrayList<>();
-		for (List<Update> updates : possibleUpdatesByIU.values())
+		for (List<Update> updates : possibleUpdatesByIU.values()) {
 			all.addAll(updates);
+		}
 		return all.toArray(new Update[all.size()]);
 	}
 
@@ -171,8 +173,9 @@ public class UpdateOperation extends ProfileChangeOperation {
 		HashSet<Update> elementsToPlan = new HashSet<>();
 		boolean selectionSpecified = defaultUpdates != null;
 		IProfile profile = session.getProfileRegistry().getProfile(profileId);
-		if (profile == null)
+		if (profile == null) {
 			return;
+		}
 
 		SubMonitor sub = SubMonitor.convert(monitor, Messages.UpdateOperation_ProfileChangeRequestProgress, 100 * iusToUpdate.size());
 		for (IInstallableUnit iuToUpdate : iusToUpdate) {
@@ -241,8 +244,9 @@ public class UpdateOperation extends ProfileChangeOperation {
 				defaultUpdates = new ArrayList<>();
 				defaultUpdates.add(update);
 			} else {
-				if (!defaultUpdates.contains(update))
+				if (!defaultUpdates.contains(update)) {
 					defaultUpdates.add(update);
+				}
 			}
 			request.add(theUpdate);
 			request.setInstallableUnitProfileProperty(theUpdate, IProfile.PROP_PROFILE_ROOT_IU, Boolean.toString(true));
@@ -286,8 +290,9 @@ public class UpdateOperation extends ProfileChangeOperation {
 	 */
 	private Collection<IInstallableUnit> getInstalledIUs() {
 		IProfile profile = session.getProfileRegistry().getProfile(profileId);
-		if (profile == null)
+		if (profile == null) {
 			return Collections.emptyList();
+		}
 		IQuery<IInstallableUnit> query = new UserVisibleRootQuery();
 		IQueryResult<IInstallableUnit> queryResult = profile.query(query, null);
 		return queryResult.toUnmodifiableSet();


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

