### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.publisher.eclipse

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/BundleDescriptionImpl.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/BundleDescriptionImpl.java
@@ -429,10 +429,9 @@ final class BundleDescriptionImpl extends BaseDescriptionImpl implements BundleD
 
 	@Override
 	public boolean compare(KeyedElement other) {
-		if (!(other instanceof BundleDescriptionImpl)) {
+		if (!(other instanceof BundleDescriptionImpl otherBundleDescription)) {
 			return false;
 		}
-		BundleDescriptionImpl otherBundleDescription = (BundleDescriptionImpl) other;
 		return bundleId == otherBundleDescription.bundleId;
 	}
 
@@ -733,10 +732,9 @@ final class BundleDescriptionImpl extends BaseDescriptionImpl implements BundleD
 
 		@Override
 		public boolean equals(Object obj) {
-			if (!(obj instanceof BundleWireImpl)) {
+			if (!(obj instanceof BundleWireImpl other)) {
 				return false;
 			}
-			BundleWireImpl other = (BundleWireImpl) obj;
 			return capability.equals(other.getCapability()) && requirement.equals(other.getRequirement()) && provider.equals(other.getProviderWiring()) && requirer.equals(other.getRequirerWiring());
 		}
 

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/BundleSpecificationImpl.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/BundleSpecificationImpl.java
@@ -73,10 +73,9 @@ class BundleSpecificationImpl extends VersionConstraintImpl implements BundleSpe
 
 	@Override
 	public boolean isSatisfiedBy(BaseDescription supplier) {
-		if (!(supplier instanceof BundleDescriptionImpl)) {
+		if (!(supplier instanceof BundleDescriptionImpl candidate)) {
 			return false;
 		}
-		BundleDescriptionImpl candidate = (BundleDescriptionImpl) supplier;
 		if (candidate.getHost() != null) {
 			return false;
 		}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/GenericSpecificationImpl.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/GenericSpecificationImpl.java
@@ -57,10 +57,9 @@ class GenericSpecificationImpl extends VersionConstraintImpl implements GenericS
 
 	@Override
 	public boolean isSatisfiedBy(BaseDescription supplier) {
-		if (!(supplier instanceof GenericDescription)) {
+		if (!(supplier instanceof GenericDescription candidate)) {
 			return false;
 		}
-		GenericDescription candidate = (GenericDescription) supplier;
 		if (!getType().equals(candidate.getType())) {
 			return false;
 		}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/HostSpecificationImpl.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/HostSpecificationImpl.java
@@ -49,10 +49,9 @@ class HostSpecificationImpl extends VersionConstraintImpl implements HostSpecifi
 
 	@Override
 	public boolean isSatisfiedBy(BaseDescription supplier) {
-		if (!(supplier instanceof BundleDescriptionImpl)) {
+		if (!(supplier instanceof BundleDescriptionImpl candidate)) {
 			return false;
 		}
-		BundleDescriptionImpl candidate = (BundleDescriptionImpl) supplier;
 		if (candidate.getHost() != null) {
 			return false;
 		}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/VersionConstraintImpl.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/internal/p2/publisher/eclipse/bundledescription/VersionConstraintImpl.java
@@ -206,8 +206,7 @@ abstract class VersionConstraintImpl implements VersionConstraint {
 	}
 
 	static StringBuilder addFilterAttribute(StringBuilder filter, String attr, Object value, boolean escapeWildCard) {
-		if (value instanceof VersionRange) {
-			VersionRange range = (VersionRange) value;
+		if (value instanceof VersionRange range) {
 			filter.append(range.toFilterString(attr));
 		} else {
 			filter.append('(').append(attr).append('=').append(escapeValue(value, escapeWildCard)).append(')');

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/BundlesAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/BundlesAction.java
@@ -537,8 +537,7 @@ public class BundlesAction extends AbstractPublisherAction {
 	}
 
 	private Object convertScalarAttribute(Object attr) {
-		if (attr instanceof org.osgi.framework.Version) {
-			org.osgi.framework.Version osgiVer = (org.osgi.framework.Version) attr;
+		if (attr instanceof org.osgi.framework.Version osgiVer) {
 			return Version.createOSGi(osgiVer.getMajor(), osgiVer.getMinor(), osgiVer.getMicro(),
 					osgiVer.getQualifier());
 		}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/EclipsePublisherHelper.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/equinox/p2/publisher/eclipse/EclipsePublisherHelper.java
@@ -40,9 +40,7 @@ public class EclipsePublisherHelper {
 	}
 
 	private static void addExtraProperties(IInstallableUnit iiu, Map<String, String> extraProperties) {
-		if (iiu instanceof InstallableUnit) {
-			InstallableUnit iu = (InstallableUnit) iiu;
-
+		if (iiu instanceof InstallableUnit iu) {
 			for (Entry<String, String> entry : extraProperties.entrySet()) {
 				iu.setProperty(entry.getKey(), entry.getValue());
 			}

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/swt/tools/IconExe.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src/org/eclipse/pde/internal/swt/tools/IconExe.java
@@ -1022,10 +1022,9 @@ public class IconExe {
 			if (object == this) {
 				return true;
 			}
-			if (!(object instanceof RGB)) {
+			if (!(object instanceof RGB rgb)) {
 				return false;
 			}
-			RGB rgb = (RGB) object;
 			return (rgb.red == this.red) && (rgb.green == this.green) && (rgb.blue == this.blue);
 		}
 

--- a/bundles/org.eclipse.equinox.p2.publisher.eclipse/src_ant/org/eclipse/equinox/internal/p2/publisher/ant/FeaturesAndBundlesPublisherTask.java
+++ b/bundles/org.eclipse.equinox.p2.publisher.eclipse/src_ant/org/eclipse/equinox/internal/p2/publisher/ant/FeaturesAndBundlesPublisherTask.java
@@ -56,9 +56,7 @@ public class FeaturesAndBundlesPublisherTask extends AbstractPublishTask {
 	private File[] getLocations(List<Object> collection) {
 		ArrayList<Object> results = new ArrayList<>();
 		for (Object obj : collection) {
-			if (obj instanceof FileSet) {
-				FileSet set = (FileSet) obj;
-
+			if (obj instanceof FileSet set) {
 				DirectoryScanner scanner = set.getDirectoryScanner(getProject());
 				String[][] elements = new String[][] {scanner.getIncludedDirectories(), scanner.getIncludedFiles()};
 				for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

