### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.publisher

### DIFF
--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/AbstractPublisherAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/AbstractPublisherAction.java
@@ -213,8 +213,7 @@ public abstract class AbstractPublisherAction implements IPublisherAction {
 	protected Collection<IRequirement> createIURequirements(Collection<? extends IVersionedId> children) {
 		ArrayList<IRequirement> result = new ArrayList<>(children.size());
 		for (IVersionedId next : children) {
-			if (next instanceof IInstallableUnit) {
-				IInstallableUnit iu = (IInstallableUnit) next;
+			if (next instanceof IInstallableUnit iu) {
 				VersionRange range = new VersionRange(iu.getVersion(), true, iu.getVersion(), true);
 				result.add(MetadataFactory.createRequirement(IInstallableUnit.NAMESPACE_IU_ID, iu.getId(), range,
 						iu.getFilter() == null ? null : iu.getFilter(), false, false));
@@ -471,11 +470,10 @@ public abstract class AbstractPublisherAction implements IPublisherAction {
 	}
 
 	protected static IRequiredCapability toRequiredCapability(IRequirement requirement) {
-		if (!(requirement instanceof IRequiredCapability)) {
+		if (!(requirement instanceof IRequiredCapability requiredCapability)) {
 			return null;
 		}
 
-		IRequiredCapability requiredCapability = (IRequiredCapability) requirement;
 		if (!RequiredCapability.isVersionRangeRequirement(requiredCapability.getMatches())) {
 			return null;
 		}

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/RootIUAction.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/RootIUAction.java
@@ -141,8 +141,7 @@ public class RootIUAction extends AbstractPublisherAction {
 				for (Object object : list) {
 					// if the advice is a string, look it up in the result.  if not there then 
 					// query the known metadata repos
-					if (object instanceof String) {
-						String childId = (String) object;
+					if (object instanceof String childId) {
 						IInstallableUnit iu = queryForIU(result, childId, getVersionAdvice(childId));
 						if (iu != null) {
 							children.add(iu);

--- a/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/VersionAdvice.java
+++ b/bundles/org.eclipse.equinox.p2.publisher/src/org/eclipse/equinox/p2/publisher/actions/VersionAdvice.java
@@ -109,10 +109,9 @@ public class VersionAdvice extends AbstractAdvice implements IVersionAdvice {
 	}
 
 	public IPublisherAdvice merge(IPublisherAdvice advice) {
-		if (!(advice instanceof VersionAdvice)) {
+		if (!(advice instanceof VersionAdvice source)) {
 			return this;
 		}
-		VersionAdvice source = (VersionAdvice) advice;
 		for (String namespace : source.versions.keySet()) {
 			Map<String, Version> myValues = versions.get(namespace);
 			Map<String, Version> sourceValues = source.versions.get(namespace);


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

