### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.repository.tools

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/RecreateRepositoryApplication.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/RecreateRepositoryApplication.java
@@ -126,11 +126,10 @@ public class RecreateRepositoryApplication extends AbstractApplication {
 
 		IArtifactRepository repository = manager.createRepository(repoLocation, repoName,
 				IArtifactRepositoryManager.TYPE_SIMPLE_REPOSITORY, repoProperties);
-		if (!(repository instanceof IFileArtifactRepository)) {
+		if (!(repository instanceof IFileArtifactRepository simple)) {
 			throw new ProvisionException(NLS.bind(Messages.exception_notLocalFileRepo, repository.getLocation()));
 		}
 
-		IFileArtifactRepository simple = (IFileArtifactRepository) repository;
 		for (IArtifactKey key : repoMap.keySet()) {
 			IArtifactDescriptor[] descriptors = repoMap.get(key);
 

--- a/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/analyzer/HostCheckAnalyzer.java
+++ b/bundles/org.eclipse.equinox.p2.repository.tools/src/org/eclipse/equinox/p2/internal/repository/tools/analyzer/HostCheckAnalyzer.java
@@ -35,8 +35,7 @@ public class HostCheckAnalyzer extends IUAnalyzer {
 
 	@Override
 	public void analyzeIU(IInstallableUnit iu) {
-		if (iu instanceof IInstallableUnitFragment) {
-			IInstallableUnitFragment fragment = (IInstallableUnitFragment) iu;
+		if (iu instanceof IInstallableUnitFragment fragment) {
 			Collection<IRequirement> hosts = fragment.getHost();
 			for (IRequirement req : hosts) {
 				IMatchExpression<IInstallableUnit> hostMatch = req.getMatches();


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

