### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.repository

### DIFF
--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/CacheManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/CacheManager.java
@@ -372,8 +372,7 @@ public class CacheManager {
 	private void registerRepoEventListener(IProvisioningEventBus eventBus) {
 		if (busListener == null) {
 			busListener = o -> {
-				if (o instanceof RepositoryEvent) {
-					RepositoryEvent event = (RepositoryEvent) o;
+				if (o instanceof RepositoryEvent event) {
 					if (RepositoryEvent.REMOVED == event.getKind() && IRepository.TYPE_METADATA == event.getRepositoryType()) {
 						deleteCache(event.getRepositoryLocation());
 					}

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/AbstractRepositoryManager.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/internal/p2/repository/helpers/AbstractRepositoryManager.java
@@ -904,8 +904,7 @@ public abstract class AbstractRepositoryManager<T> implements IRepositoryManager
 
 	@Override
 	public void notify(EventObject o) {
-		if (o instanceof RepositoryEvent) {
-			RepositoryEvent event = (RepositoryEvent) o;
+		if (o instanceof RepositoryEvent event) {
 			if (event.getKind() == RepositoryEvent.DISCOVERED && event.getRepositoryType() == getRepositoryType()) {
 				RepositoryInfo<T> info = new RepositoryInfo<>();
 				info.location = event.getRepositoryLocation();

--- a/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/artifact/spi/ProcessingStepDescriptor.java
+++ b/bundles/org.eclipse.equinox.p2.repository/src/org/eclipse/equinox/p2/repository/artifact/spi/ProcessingStepDescriptor.java
@@ -73,10 +73,9 @@ public class ProcessingStepDescriptor implements IProcessingStepDescriptor {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof IProcessingStepDescriptor)) {
+		if (!(obj instanceof final IProcessingStepDescriptor other)) {
 			return false;
 		}
-		final IProcessingStepDescriptor other = (IProcessingStepDescriptor) obj;
 		if (data == null) {
 			if (other.getData() != null) {
 				return false;


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

