### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.tests

### DIFF
--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/GenerateTestData.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/GenerateTestData.java
@@ -59,10 +59,9 @@ public class GenerateTestData {
 
 		@Override
 		public boolean equals(Object obj) {
-			if (!(obj instanceof TestBundle)) {
+			if (!(obj instanceof TestBundle other)) {
 				return false;
 			}
-			TestBundle other = (TestBundle) obj;
 			return id.equals(other.id) && version.equals(other.version);
 		}
 

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/IULoader.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/IULoader.java
@@ -34,8 +34,8 @@ public class IULoader {
 		for (Field field : fields) {
 			Annotation[] a = field.getAnnotations();
 			for (Annotation a1 : a) {
-				if (a1 instanceof IUDescription) {
-					IUDescription ml = (IUDescription) a1; // here it is !!!
+				if (a1 instanceof IUDescription ml) {
+					 // here it is !!!
 					ReducedCUDFParser parser = new ReducedCUDFParser();
 					try (final InputStream is = new ByteArrayInputStream(ml.content().getBytes())) {
 						parser.parse(is, false, null);

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/TestRepositoryListener.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/TestRepositoryListener.java
@@ -37,10 +37,9 @@ public class TestRepositoryListener implements SynchronousProvisioningListener {
 
 	@Override
 	public void notify(EventObject o) {
-		if (!(o instanceof RepositoryEvent)) {
+		if (!(o instanceof RepositoryEvent event)) {
 			return;
 		}
-		RepositoryEvent event = (RepositoryEvent) o;
 		if (repoLocation != null && !event.getRepositoryLocation().equals(repoLocation)) {
 			return;
 		}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/PGPSignatureVerifierTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/processors/PGPSignatureVerifierTest.java
@@ -49,8 +49,7 @@ public class PGPSignatureVerifierTest {
 	public void initialize() {
 		try {
 			PGPPublicKeyService keyService = agentProvider.getService(PGPPublicKeyService.class);
-			if (keyService instanceof DefaultPGPPublicKeyService) {
-				DefaultPGPPublicKeyService defaultPGPPublicKeyService = (DefaultPGPPublicKeyService) keyService;
+			if (keyService instanceof DefaultPGPPublicKeyService defaultPGPPublicKeyService) {
 				defaultPGPPublicKeyService.setKeyServers(Set.of());
 				defaultPGPPublicKeyService.setGPG(false);
 			}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/SimpleArtifactRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/artifact/repository/SimpleArtifactRepositoryTest.java
@@ -308,11 +308,10 @@ public class SimpleArtifactRepositoryTest extends AbstractProvisioningTest {
 			if (obj == null) {
 				return false;
 			}
-			if (!(obj instanceof IArtifactDescriptor)) {
+			if (!(obj instanceof IArtifactDescriptor other)) {
 				return false;
 			}
 
-			IArtifactDescriptor other = (IArtifactDescriptor) obj;
 			if (!artifactKey.equals(other.getArtifactKey())) {
 				return false;
 			}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/director/OperationGenerationTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/director/OperationGenerationTest.java
@@ -375,10 +375,9 @@ public class OperationGenerationTest extends AbstractProvisioningTest {
 
 	private void assertContainsInstallableUnitOperand(String message, List<Operand> operands, InstallableUnitOperand operand) {
 		for (Operand op : operands) {
-			if (!(op instanceof InstallableUnitOperand)) {
+			if (!(op instanceof InstallableUnitOperand cmp)) {
 				continue;
 			}
-			InstallableUnitOperand cmp = (InstallableUnitOperand) op;
 			if (cmp.first() != null && cmp.first().equals(operand.first()) && cmp.second() != null && cmp.second().equals(operand.second())) {
 				return;
 			}
@@ -508,10 +507,9 @@ public class OperationGenerationTest extends AbstractProvisioningTest {
 
 	public void assertContainsConfigurationChange(String message, List<Operand> operands) {
 		for (Operand operand : operands) {
-			if (!(operand instanceof InstallableUnitOperand)) {
+			if (!(operand instanceof InstallableUnitOperand op)) {
 				continue;
 			}
-			InstallableUnitOperand op = (InstallableUnitOperand) operand;
 			if (op.first() != null && op.first().equals(op.second())) {
 				return;
 			}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/engine/ProvisioningEventTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/engine/ProvisioningEventTest.java
@@ -153,8 +153,7 @@ public class ProvisioningEventTest extends AbstractProvisioningTest {
 
 			@Override
 			public void notify(EventObject o) {
-				if (o instanceof PhaseEvent) {
-					PhaseEvent event = (PhaseEvent) o;
+				if (o instanceof PhaseEvent event) {
 					if (event.getType() == PhaseEvent.TYPE_START) {
 						if (!phaseStartEventToBePublised.remove(event.getPhaseId())) {
 							publishUnWantedPhaseEvent = event.getPhaseId();
@@ -209,8 +208,7 @@ public class ProvisioningEventTest extends AbstractProvisioningTest {
 
 			@Override
 			public void notify(EventObject o) {
-				if (o instanceof InstallableUnitEvent) {
-					InstallableUnitEvent event = (InstallableUnitEvent) o;
+				if (o instanceof InstallableUnitEvent event) {
 					if (event.getPhase().equals(PhaseSetFactory.PHASE_CONFIGURE) && event.isConfigure() && event.getInstallableUnit().getId().equals(iuId)) {
 						if (event.isPre()) {
 							preConfigureEvent++;
@@ -304,8 +302,7 @@ public class ProvisioningEventTest extends AbstractProvisioningTest {
 
 			@Override
 			public void notify(EventObject o) {
-				if (o instanceof InstallableUnitEvent) {
-					InstallableUnitEvent event = (InstallableUnitEvent) o;
+				if (o instanceof InstallableUnitEvent event) {
 					if (event.getPhase().equals(PhaseSetFactory.PHASE_CONFIGURE) && event.getInstallableUnit().getId().equals(iuId)) {
 						if (event.isConfigure() && event.isPre()) {
 							preConfigureEvent++;

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/LocalMetadataRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/LocalMetadataRepositoryTest.java
@@ -192,10 +192,9 @@ public class LocalMetadataRepositoryTest extends AbstractProvisioningTest {
 		final boolean[] wasEnabled = new boolean[] {false};
 		//add a listener to ensure we receive add events with the repository enabled
 		SynchronousProvisioningListener listener = o -> {
-			if (!(o instanceof RepositoryEvent)) {
+			if (!(o instanceof RepositoryEvent event)) {
 				return;
 			}
-			RepositoryEvent event = (RepositoryEvent) o;
 			if (event.getKind() != RepositoryEvent.ADDED) {
 				return;
 			}
@@ -235,10 +234,9 @@ public class LocalMetadataRepositoryTest extends AbstractProvisioningTest {
 		final boolean[] wasEnabled = new boolean[] {false};
 		//add a listener to ensure we receive add events with the repository enabled
 		SynchronousProvisioningListener listener = o -> {
-			if (!(o instanceof RepositoryEvent)) {
+			if (!(o instanceof RepositoryEvent event)) {
 				return;
 			}
-			RepositoryEvent event = (RepositoryEvent) o;
 			if (event.getKind() != RepositoryEvent.ADDED) {
 				return;
 			}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/MetadataRepositoryManagerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/MetadataRepositoryManagerTest.java
@@ -485,10 +485,9 @@ public class MetadataRepositoryManagerTest extends AbstractProvisioningTest {
 		URI location = site.toURI();
 		final List<URI> references = new ArrayList<>();
 		SynchronousProvisioningListener referenceCollector = o -> {
-			if (!(o instanceof RepositoryEvent)) {
+			if (!(o instanceof RepositoryEvent event)) {
 				return;
 			}
-			RepositoryEvent event = (RepositoryEvent) o;
 			if (event.getKind() == RepositoryEvent.DISCOVERED) {
 				references.add(event.getRepositoryLocation());
 			}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/SPIMetadataRepositoryTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/metadata/repository/SPIMetadataRepositoryTest.java
@@ -141,11 +141,10 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 				return true;
 			}
 
-			if (!(obj instanceof IRequirement)) {
+			if (!(obj instanceof IRequirement other)) {
 				return false;
 			}
 
-			IRequirement other = (IRequirement) obj;
 			if (filter == null) {
 				if (other.getFilter() != null) {
 					return false;
@@ -197,11 +196,10 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 
 		@Override
 		public boolean equals(Object other) {
-			if (!(other instanceof IProvidedCapability)) {
+			if (!(other instanceof IProvidedCapability otherCapability)) {
 				return false;
 			}
 
-			IProvidedCapability otherCapability = (IProvidedCapability) other;
 			if (!(namespace.equals(otherCapability.getNamespace()))) {
 				return false;
 			}
@@ -418,10 +416,9 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 			if (obj == null) {
 				return false;
 			}
-			if (!(obj instanceof ITouchpointData)) {
+			if (!(obj instanceof final ITouchpointData other)) {
 				return false;
 			}
-			final ITouchpointData other = (ITouchpointData) obj;
 			if (instructions == null) {
 				if (other.getInstructions() != null) {
 					return false;
@@ -461,10 +458,9 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 			if (obj == null) {
 				return false;
 			}
-			if (!(obj instanceof ITouchpointInstruction)) {
+			if (!(obj instanceof ITouchpointInstruction other)) {
 				return false;
 			}
-			ITouchpointInstruction other = (ITouchpointInstruction) obj;
 			if (body == null) {
 				if (other.getBody() != null) {
 					return false;
@@ -511,10 +507,9 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 			if (super.equals(obj)) {
 				return true;
 			}
-			if (obj == null || !(obj instanceof ITouchpointType)) {
+			if (obj == null || !(obj instanceof ITouchpointType other)) {
 				return false;
 			}
-			ITouchpointType other = (ITouchpointType) obj;
 			return id.equals(other.getId()) && version.equals(other.getVersion());
 		}
 	}
@@ -614,10 +609,9 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 			if (obj == null) {
 				return false;
 			}
-			if (!(obj instanceof IRequirementChange)) {
+			if (!(obj instanceof final IRequirementChange other)) {
 				return false;
 			}
-			final IRequirementChange other = (IRequirementChange) obj;
 			if (applyOn == null) {
 				if (other.applyOn() != null) {
 					return false;
@@ -679,8 +673,7 @@ public class SPIMetadataRepositoryTest extends AbstractProvisioningTest {
 			if (obj == null) {
 				return false;
 			}
-			if (obj instanceof ILicense) {
-				ILicense other = (ILicense) obj;
+			if (obj instanceof ILicense other) {
 				if (other.getUUID().equals(getUUID())) {
 					return true;
 				}

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/planner/AbstractPlannerTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/planner/AbstractPlannerTest.java
@@ -64,10 +64,9 @@ public abstract class AbstractPlannerTest extends AbstractProvisioningTest {
 		Map<String, InstallableUnitOperand> result = new HashMap<>();
 		Operand[] operands = ((ProvisioningPlan) plan).getOperands();
 		for (Operand oper : operands) {
-			if (!(oper instanceof InstallableUnitOperand)) {
+			if (!(oper instanceof InstallableUnitOperand operand)) {
 				continue;
 			}
-			InstallableUnitOperand operand = (InstallableUnitOperand) oper;
 			String id = operand.first() == null ? operand.second().getId() : operand.first().getId();
 			InstallableUnitOperand existing = result.get(id);
 			if (existing == null) {
@@ -177,10 +176,9 @@ public abstract class AbstractPlannerTest extends AbstractProvisioningTest {
 			// see if there is an operand in the actual plan which involved this IU.
 			boolean found = false;
 			for (Operand actualOperand : actualOperands) {
-				if (!(actualOperand instanceof InstallableUnitOperand)) {
+				if (!(actualOperand instanceof InstallableUnitOperand actual)) {
 					continue;
 				}
-				InstallableUnitOperand actual = (InstallableUnitOperand) actualOperand;
 				// handle removals
 				if (second == null) {
 					if (actual.second() != null) {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/planner/Bug302580.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/planner/Bug302580.java
@@ -47,8 +47,7 @@ public class Bug302580 extends AbstractPlannerTest {
 
 		String message = "The plan:\n";
 		for (Operand op : ops) {
-			if (op instanceof InstallableUnitOperand) {
-				InstallableUnitOperand iuo = (InstallableUnitOperand) op;
+			if (op instanceof InstallableUnitOperand iuo) {
 				if (iuo.first() == null) {
 					message += iuo.second() + " will be installed\n";
 				}
@@ -63,8 +62,7 @@ public class Bug302580 extends AbstractPlannerTest {
 		System.out.println(message);
 
 		for (Operand op : ops) {
-			if (op instanceof InstallableUnitOperand) {
-				InstallableUnitOperand iuo = (InstallableUnitOperand) op;
+			if (op instanceof InstallableUnitOperand iuo) {
 				if (iuo.second() == null) {
 					String id = iuo.first().getId();
 					if (id.equals("toolingorg.eclipse.equinox.launcher") || id.equals("toolingorg.eclipse.equinox.p2.reconciler.dropins") || id.equals("toolingorg.eclipse.equinox.simpleconfigurator")) {

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ProductActionTest.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/publisher/actions/ProductActionTest.java
@@ -425,8 +425,7 @@ public class ProductActionTest extends ActionTest {
 		IInstallableUnit aJre = publisherResult.getIUs("a.jre.javase", IPublisherResult.ROOT).iterator().next();
 		boolean found = false;
 		for (IRequirement req : productIU.getRequirements()) {
-			if (req instanceof RequiredCapability) {
-				RequiredCapability required = (RequiredCapability) req;
+			if (req instanceof RequiredCapability required) {
 				if (JREAction.NAMESPACE_OSGI_EE.equals(required.getNamespace())) {
 					found = true;
 					assertEquals("OSGi/Minimum", required.getName());

--- a/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/updatechecker/TestUpdateListener.java
+++ b/bundles/org.eclipse.equinox.p2.tests/src/org/eclipse/equinox/p2/tests/updatechecker/TestUpdateListener.java
@@ -34,10 +34,9 @@ public class TestUpdateListener implements IUpdateListener {
 	}
 
 	public boolean matches(Object o) {
-		if (!(o instanceof UpdateEvent)) {
+		if (!(o instanceof UpdateEvent actual)) {
 			return false;
 		}
-		UpdateEvent actual = (UpdateEvent) o;
 		return Arrays.equals(expectedEvent.getIUs().toArray(), actual.getIUs().toArray()) && expectedEvent.getProfileId().equals(actual.getProfileId());
 	}
 


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

