### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.touchpoint.eclipse

### DIFF
--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/touchpoint/eclipse/Util.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/touchpoint/eclipse/Util.java
@@ -251,8 +251,7 @@ public class Util {
 	private static String getFragmentHost(IInstallableUnit unit, String fragmentName) {
 		Collection<IRequirement> requires = unit.getRequirements();
 		for (IRequirement iRequirement : requires) {
-			if (iRequirement instanceof IRequiredCapability) {
-				IRequiredCapability requiredCapability = (IRequiredCapability) iRequirement;
+			if (iRequirement instanceof IRequiredCapability requiredCapability) {
 				if (fragmentName.equals(requiredCapability.getName())) {
 					String fragmentHost = requiredCapability.getName();
 					if (!requiredCapability.getRange().toString().equals("0.0.0")) { //$NON-NLS-1$

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/update/Feature.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/update/Feature.java
@@ -108,10 +108,9 @@ public class Feature {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (!(obj instanceof Feature)) {
+		if (!(obj instanceof Feature other)) {
 			return false;
 		}
-		Feature other = (Feature) obj;
 		if (!equals(getId(), other.getId())) {
 			return false;
 		}

--- a/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/update/Site.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.eclipse/src/org/eclipse/equinox/internal/p2/update/Site.java
@@ -143,10 +143,9 @@ public class Site {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (!(obj instanceof Site)) {
+		if (!(obj instanceof Site other)) {
 			return false;
 		}
-		Site other = (Site) obj;
 		if (isEnabled() != other.isEnabled()) {
 			return false;
 		}


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

