### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.touchpoint.natives

### DIFF
--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/LazyBackupStore.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/LazyBackupStore.java
@@ -46,21 +46,24 @@ public class LazyBackupStore implements IBackupStore {
 
 	@Override
 	public void discard() {
-		if (delegate == null)
+		if (delegate == null) {
 			return;
+		}
 		delegate.discard();
 	}
 
 	@Override
 	public void restore() throws IOException {
-		if (delegate == null)
+		if (delegate == null) {
 			return;
+		}
 		delegate.restore();
 	}
 
 	private void loadDelegate() {
-		if (delegate != null)
+		if (delegate != null) {
 			return;
+		}
 		delegate = new SimpleBackupStore(null, prefix);
 	}
 

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/NativePackageExtractionApplication.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/NativePackageExtractionApplication.java
@@ -90,10 +90,11 @@ public class NativePackageExtractionApplication implements IApplication {
 
 			if (OPTION_TO_ANALYZE.equals(opt)) {
 				installation = new File(getRequiredArgument(args, ++i));
-				if (!installation.exists())
+				if (!installation.exists()) {
 					throw new CoreException(new Status(IStatus.ERROR, Activator.ID,
 							Messages.NativePackageExtractionApplication_FolderNotFound
 									+ installation.getAbsolutePath()));
+				}
 				continue;
 			}
 
@@ -107,8 +108,9 @@ public class NativePackageExtractionApplication implements IApplication {
 	private static String getRequiredArgument(String[] args, int argIdx) throws CoreException {
 		if (argIdx < args.length) {
 			String arg = args[argIdx];
-			if (!arg.startsWith("-")) //$NON-NLS-1$
+			if (!arg.startsWith("-")) { //$NON-NLS-1$
 				return arg;
+			}
 		}
 		throw new ProvisionException(
 				NLS.bind(Messages.NativePackageExtractionApplication_MissingValue, args[argIdx - 1]));
@@ -133,8 +135,9 @@ public class NativePackageExtractionApplication implements IApplication {
 
 	private void collectLauncherName(IProfile p) {
 		String launcherName = p.getProperty("eclipse.touchpoint.launcherName"); //$NON-NLS-1$
-		if (launcherName == null)
+		if (launcherName == null) {
 			launcherName = ""; //$NON-NLS-1$
+		}
 		extractedData.put(PROP_LAUNCHER_NAME, launcherName);
 	}
 
@@ -146,8 +149,9 @@ public class NativePackageExtractionApplication implements IApplication {
 				int i = entry.indexOf('=');
 				String key = entry.substring(0, i).trim();
 				String value = entry.substring(i + 1).trim();
-				if (!key.equals("osgi.arch")) //$NON-NLS-1$
+				if (!key.equals("osgi.arch")) { //$NON-NLS-1$
 					continue;
+				}
 
 				if ("x86_64".equals(value)) { //$NON-NLS-1$
 					extractedData.put(PROP_ARCH, "amd64"); //$NON-NLS-1$
@@ -189,16 +193,18 @@ public class NativePackageExtractionApplication implements IApplication {
 			}
 		}
 		// pre-prend a comma, and remove the last one
-		if (depends.length() > 0)
+		if (depends.length() > 0) {
 			depends = ',' + depends.substring(0, depends.length() - 1);
+		}
 
 		extractedData.put(PROP_DEPENDS, depends);
 	}
 
 	private String formatAsDependsEntry(String packageId, String version, String versionComparator) {
 		String result = packageId;
-		if (versionComparator == null)
+		if (versionComparator == null) {
 			versionComparator = DEFAULT_VERSION_CONSTRAINT;
+		}
 		if (version != null) {
 			result += '(' + getUserFriendlyComparator(versionComparator) + ' ' + version + ')';
 		}
@@ -215,20 +221,23 @@ public class NativePackageExtractionApplication implements IApplication {
 
 		int openBracket = statement.indexOf('(');
 		int closeBracket = statement.lastIndexOf(')');
-		if (openBracket == -1 || closeBracket == -1 || openBracket > closeBracket)
+		if (openBracket == -1 || closeBracket == -1 || openBracket > closeBracket) {
 			return null;
+		}
 		instructions.put(_ACTION_ID, statement.substring(0, openBracket).trim());
 
 		String nameValuePairs = statement.substring(openBracket + 1, closeBracket);
-		if (nameValuePairs.length() == 0)
+		if (nameValuePairs.length() == 0) {
 			return instructions;
+		}
 
 		StringTokenizer tokenizer = new StringTokenizer(nameValuePairs, ","); //$NON-NLS-1$
 		while (tokenizer.hasMoreTokens()) {
 			String nameValuePair = tokenizer.nextToken();
 			int colonIndex = nameValuePair.indexOf(":"); //$NON-NLS-1$
-			if (colonIndex == -1)
+			if (colonIndex == -1) {
 				return null;
+			}
 			String name = nameValuePair.substring(0, colonIndex).trim();
 			String value = nameValuePair.substring(colonIndex + 1).trim();
 			instructions.put(name, value);
@@ -256,23 +265,27 @@ public class NativePackageExtractionApplication implements IApplication {
 				} catch (IOException e) {
 					// Ignore
 				}
-				if (profileId == null)
+				if (profileId == null) {
 					profileId = installation.toString();
+				}
 			}
 		}
-		if (profileId != null)
+		if (profileId != null) {
 			targetAgent.registerService(PROP_P2_PROFILE, profileId);
+		}
 	}
 
 	private static void appendLevelPrefix(PrintStream strm, int level) {
-		for (int idx = 0; idx < level; ++idx)
+		for (int idx = 0; idx < level; ++idx) {
 			strm.print(' ');
+		}
 	}
 
 	private void deeplyPrint(CoreException ce, PrintStream strm, int level) {
 		appendLevelPrefix(strm, level);
-		if (stackTrace)
+		if (stackTrace) {
 			ce.printStackTrace(strm);
+		}
 		deeplyPrint(ce.getStatus(), strm, level);
 	}
 
@@ -283,8 +296,9 @@ public class NativePackageExtractionApplication implements IApplication {
 		Throwable cause = status.getException();
 		if (cause != null) {
 			strm.print("Caused by: "); //$NON-NLS-1$
-			if (stackTrace || !(msg.equals(cause.getMessage()) || msg.equals(cause.toString())))
+			if (stackTrace || !(msg.equals(cause.getMessage()) || msg.equals(cause.toString()))) {
 				deeplyPrint(cause, strm, level);
+			}
 		}
 
 		if (status.isMultiStatus()) {
@@ -296,13 +310,13 @@ public class NativePackageExtractionApplication implements IApplication {
 	}
 
 	private void deeplyPrint(Throwable t, PrintStream strm, int level) {
-		if (t instanceof CoreException)
+		if (t instanceof CoreException) {
 			deeplyPrint((CoreException) t, strm, level);
-		else {
+		} else {
 			appendLevelPrefix(strm, level);
-			if (stackTrace)
+			if (stackTrace) {
 				t.printStackTrace(strm);
-			else {
+			} else {
 				strm.println(t.toString());
 				Throwable cause = t.getCause();
 				if (cause != null) {

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/NativeTouchpoint.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/NativeTouchpoint.java
@@ -64,8 +64,9 @@ public class NativeTouchpoint extends Touchpoint {
 			try {
 				IFileArtifactRepository downloadCache = Util.getDownloadCacheRepo(agent);
 				File fileLocation = downloadCache.getArtifactFile(artifactKey);
-				if (fileLocation != null && fileLocation.exists())
+				if (fileLocation != null && fileLocation.exists()) {
 					parameters.put(PARM_ARTIFACT_LOCATION, fileLocation.getAbsolutePath());
+				}
 			} catch (ProvisionException e) {
 				return e.getStatus();
 			}
@@ -103,8 +104,9 @@ public class NativeTouchpoint extends Touchpoint {
 	}
 
 	private void promptForNativePackage() {
-		if (packagesToInstall.size() == 0)
+		if (packagesToInstall.size() == 0) {
 			return;
+		}
 		loadInstallCommandsProperties(installCommandsProperties, distro);
 		UIServices serviceUI = agent.getService(UIServices.class);
 		String text = Messages.PromptForNative_IntroText;
@@ -142,21 +144,24 @@ public class NativeTouchpoint extends Touchpoint {
 	}
 
 	private String formatVersion(NativePackageEntry entry) {
-		if (entry.getVersion() == null)
+		if (entry.getVersion() == null) {
 			return null;
+		}
 		return getUserFriendlyComparator(entry.comparator) + ' ' + entry.version + ' ';
 	}
 
 	private String getUserFriendlyComparator(String comparator) {
-		if (comparator == null)
+		if (comparator == null) {
 			return ""; //$NON-NLS-1$
+		}
 		return installCommandsProperties.getProperty(comparator, ""); //$NON-NLS-1$
 	}
 
 	public static void loadInstallCommandsProperties(Properties properties, String distro) {
 		File f = getFileFromBundle(distro, INSTALL_COMMANDS);
-		if (f == null)
+		if (f == null) {
 			return;
+		}
 
 		try (InputStream is = new BufferedInputStream(new FileInputStream(f))) {
 			properties.load(is);
@@ -170,8 +175,9 @@ public class NativeTouchpoint extends Touchpoint {
 	}
 
 	private String createCommand(List<NativePackageEntry> packageEntries) {
-		if (packageEntries.isEmpty())
+		if (packageEntries.isEmpty()) {
 			return null;
+		}
 		String text = getInstallCommad() + ' ';
 		for (NativePackageEntry nativePackageEntry : packageEntries) {
 			text += nativePackageEntry.name + " "; //$NON-NLS-1$
@@ -246,8 +252,9 @@ public class NativeTouchpoint extends Touchpoint {
 	public static File getFileFromBundle(String distro, String file) {
 		URL[] installScripts = FileLocator.findEntries(Activator.getContext().getBundle(),
 				IPath.fromOSString(NativeTouchpoint.FOLDER + '/' + distro + '/' + file));
-		if (installScripts.length == 0)
+		if (installScripts.length == 0) {
 			return null;
+		}
 
 		try {
 			return URIUtil.toFile(URIUtil.toURI(FileLocator.toFileURL(installScripts[0])));

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/BlockMacUpdate.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/BlockMacUpdate.java
@@ -27,33 +27,40 @@ public class BlockMacUpdate extends ProvisioningAction {
 
 	@Override
 	public IStatus execute(Map<String, Object> parameters) {
-		if (!runningOldMacLayout())
+		if (!runningOldMacLayout()) {
 			return Status.OK_STATUS;
+		}
 		return new Status(IStatus.ERROR, Activator.ID, Messages.BlockMacUpdate_1);
 	}
 
 	private boolean runningOldMacLayout() {
-		if (!org.eclipse.osgi.service.environment.Constants.OS_MACOSX.equals(getOS()))
+		if (!org.eclipse.osgi.service.environment.Constants.OS_MACOSX.equals(getOS())) {
 			return false;
+		}
 		Version fwkAdminVersion = getFrameworkAdminVersion();
-		if (fwkAdminVersion == null)
+		if (fwkAdminVersion == null) {
 			return false;
-		if (fwkAdminVersion.compareTo(new Version("1.0.500.v201523")) < 0) //$NON-NLS-1$
+		}
+		if (fwkAdminVersion.compareTo(new Version("1.0.500.v201523")) < 0) { //$NON-NLS-1$
 			return true;
+		}
 		return false;
 	}
 
 	private Version getFrameworkAdminVersion() {
 		ServiceReference<PackageAdmin> sr = Activator.getContext().getServiceReference(PackageAdmin.class);
-		if (sr == null)
+		if (sr == null) {
 			return null;
+		}
 		PackageAdmin packageAdmin = Activator.getContext().getService(sr);
-		if (packageAdmin == null)
+		if (packageAdmin == null) {
 			return null;
+		}
 		Activator.getContext().ungetService(sr);
 		Bundle[] bundles = packageAdmin.getBundles("org.eclipse.equinox.frameworkadmin.equinox", null); //$NON-NLS-1$
-		if (bundles == null)
+		if (bundles == null) {
 			return null;
+		}
 		//Return the first bundle that is not installed or uninstalled
 		for (Bundle bundle : bundles) {
 			if ((bundle.getState() & (Bundle.INSTALLED | Bundle.UNINSTALLED)) == 0) {
@@ -65,8 +72,9 @@ public class BlockMacUpdate extends ProvisioningAction {
 
 	private String getOS() {
 		ServiceReference<EnvironmentInfo> sr = Activator.getContext().getServiceReference(EnvironmentInfo.class);
-		if (sr == null)
+		if (sr == null) {
 			return null;
+		}
 		String value = Activator.getContext().getService(sr).getOS();
 		Activator.getContext().ungetService(sr);
 		return value;

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CheckAndPromptNativePackage.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CheckAndPromptNativePackage.java
@@ -38,20 +38,23 @@ public class CheckAndPromptNativePackage extends ProvisioningAction {
 		String versionComparator = (String) parameters.get(ActionConstants.PARM_LINUX_VERSION_COMPARATOR);
 		IInstallableUnit iu = (IInstallableUnit) parameters.get(ActionConstants.PARM_IU);
 
-		if (distro == null || packageName == null || (versionComparator != null && packageVersion == null))
+		if (distro == null || packageName == null || (versionComparator != null && packageVersion == null)) {
 			return new Status(IStatus.ERROR, Activator.ID, Messages.Incorrect_Command);
+		}
 
 		distro = distro.toLowerCase();
 
 		// If we are not running the distro we are provisioning, do nothing and return
-		if (!runningDistro(distro))
+		if (!runningDistro(distro)) {
 			return Status.OK_STATUS;
+		}
 
 		// Check if the desired package is installed and collect information in the
 		// touchpoint
 		File scriptToExecute = NativeTouchpoint.getFileFromBundle(distro, IS_INSTALLED);
-		if (scriptToExecute == null)
+		if (scriptToExecute == null) {
 			return new Status(IStatus.ERROR, Activator.ID, NLS.bind(Messages.Cannot_Find_status, distro));
+		}
 
 		try {
 			List<String> cmd = new ArrayList<>(4);
@@ -59,8 +62,9 @@ public class CheckAndPromptNativePackage extends ProvisioningAction {
 			cmd.add(scriptToExecute.getAbsolutePath());
 			cmd.add(packageName);
 			if (packageVersion != null) {
-				if (versionComparator == null)
+				if (versionComparator == null) {
 					versionComparator = "ge"; //$NON-NLS-1$
+				}
 
 				cmd.add(versionComparator);
 				cmd.add(packageVersion);
@@ -90,15 +94,17 @@ public class CheckAndPromptNativePackage extends ProvisioningAction {
 	protected boolean runningDistro(String distro) {
 		try {
 			File scriptToExecute = NativeTouchpoint.getFileFromBundle(distro, IS_RUNNING);
-			if (scriptToExecute == null)
+			if (scriptToExecute == null) {
 				return false;
+			}
 
 			List<String> cmd = new ArrayList<>(4);
 			cmd.add(SHELL);
 			cmd.add(scriptToExecute.getAbsolutePath());
 			int exitValue = new ProcessBuilder(cmd).start().waitFor();
-			if (exitValue == 0)
+			if (exitValue == 0) {
 				return true;
+			}
 			return false;
 		} catch (IOException e) {
 			return false;

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CheckAndPromptNativePackageWindowsRegistry.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CheckAndPromptNativePackageWindowsRegistry.java
@@ -33,8 +33,9 @@ public class CheckAndPromptNativePackageWindowsRegistry extends ProvisioningActi
 	@Override
 	public IStatus execute(Map<String, Object> parameters) {
 		// If we are not running on Windows, do nothing and return
-		if (!IS_WINDOWS)
+		if (!IS_WINDOWS) {
 			return Status.OK_STATUS;
+		}
 
 		// Get and check the paremeters
 		String packageName = (String) parameters.get(ActionConstants.PARM_LINUX_PACKAGE_NAME);
@@ -44,14 +45,16 @@ public class CheckAndPromptNativePackageWindowsRegistry extends ProvisioningActi
 		String attValue = (String) parameters.get(ActionConstants.PARM_WINDOWS_REGISTRY_ATTRIBUTE_VALUE);
 		IInstallableUnit iu = (IInstallableUnit) parameters.get(ActionConstants.PARM_IU);
 
-		if (key == null || (attName != null && attValue == null))
+		if (key == null || (attName != null && attValue == null)) {
 			return new Status(IStatus.ERROR, Activator.ID, Messages.Incorrect_Command);
+		}
 
 		// Check if the desired package is installed and collect information in the
 		// touchpoint
 		File scriptToExecute = NativeTouchpoint.getFileFromBundle(WINDOWS_DISTRO, IS_INSTALLED);
-		if (scriptToExecute == null)
+		if (scriptToExecute == null) {
 			return new Status(IStatus.ERROR, Activator.ID, NLS.bind(Messages.Cannot_Find_status, WINDOWS_DISTRO));
+		}
 
 		try {
 			List<String> cmd = new ArrayList<>(6);

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/ChmodAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/ChmodAction.java
@@ -97,24 +97,29 @@ public class ChmodAction extends ProvisioningAction {
 	@Override
 	public IStatus execute(Map<String, Object> parameters) {
 		// on Windows this isn't implemented, so we can return right here.
-		if (WINDOWS)
+		if (WINDOWS) {
 			return Status.OK_STATUS;
+		}
 		Object absoluteFiles = parameters.get(ActionConstants.PARM_ABSOLUTE_FILES); // String or String[]
 		String targetDir = (String) parameters.get(ActionConstants.PARM_TARGET_DIR);
 		String targetFile = (String) parameters.get(ActionConstants.PARM_TARGET_FILE);
 
-		if (targetFile != null && absoluteFiles != null)
+		if (targetFile != null && absoluteFiles != null) {
 			return Util.createError(Messages.chmod_param_cant_be_set_together);
+		}
 
-		if (targetDir != null && targetFile == null)
+		if (targetDir != null && targetFile == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_TARGET_FILE, ACTION_CHMOD));
+		}
 
-		if (targetDir == null && targetFile != null)
+		if (targetDir == null && targetFile != null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_TARGET_DIR, ACTION_CHMOD));
+		}
 
 		String permissions = (String) parameters.get(ActionConstants.PARM_PERMISSIONS);
-		if (permissions == null)
+		if (permissions == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_PERMISSIONS, ACTION_CHMOD));
+		}
 		String optionsString = (String) parameters.get(ActionConstants.PARM_OPTIONS);
 
 		String[] filesToProcess = absoluteFiles != null
@@ -184,8 +189,9 @@ public class ChmodAction extends ProvisioningAction {
 	}
 
 	public IStatus chmod(String fileToChmod, String perms, String[] options) {
-		if (WINDOWS)
+		if (WINDOWS) {
 			return Status.OK_STATUS;
+		}
 		Runtime r = Runtime.getRuntime();
 		try {
 			// Note: 3 is from chmod, permissions, and target

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CleanupcopyAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CleanupcopyAction.java
@@ -47,11 +47,13 @@ public class CleanupcopyAction extends ProvisioningAction {
 	 */
 	public static IStatus cleanupcopy(Map<String, Object> parameters, boolean restoreable) {
 		String source = (String) parameters.get(ActionConstants.PARM_SOURCE);
-		if (source == null)
+		if (source == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_SOURCE, ACTION_CLEANUPCOPY));
+		}
 		String target = (String) parameters.get(ActionConstants.PARM_TARGET);
-		if (target == null)
+		if (target == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_TARGET, ACTION_CLEANUPCOPY));
+		}
 		IBackupStore backupStore = (IBackupStore) parameters.get(NativeTouchpoint.PARM_BACKUP);
 
 		IInstallableUnit iu = (IInstallableUnit) parameters.get(ActionConstants.PARM_IU);
@@ -59,47 +61,52 @@ public class CleanupcopyAction extends ProvisioningAction {
 
 		String copied = profile.getInstallableUnitProperty(iu, CopyAction.buildCopiedFileIUPropertyKey(target, source));
 
-		if (copied == null)
+		if (copied == null) {
 			return Status.OK_STATUS;
+		}
 
 		StringTokenizer tokenizer = new StringTokenizer(copied, ActionConstants.PIPE);
 		List<File> directories = new ArrayList<>();
 		while (tokenizer.hasMoreTokens()) {
 			String fileName = tokenizer.nextToken();
 			File file = new File(fileName);
-			if (!file.exists())
+			if (!file.exists()) {
 				continue;
+			}
 
 			// directories need to be deleted from the bottom-up, but directories are listed
 			// in traversal order during copy, so we need to reverse the directory list
-			if (file.isDirectory())
+			if (file.isDirectory()) {
 				directories.add(0, file);
-			else {
-				if (restoreable)
+			} else {
+				if (restoreable) {
 					try {
 						backupStore.backup(file);
 					} catch (IOException e) {
 						return Util.createError(NLS.bind(Messages.backup_file_failed, file));
 					}
-				else
+				} else {
 					file.delete();
+				}
 			}
 		}
 
 		for (File directory : directories) {
 			File[] children = directory.listFiles();
-			if (children == null)
+			if (children == null) {
 				return Util.createError(NLS.bind(Messages.Error_list_children_0, directory));
+			}
 
 			if (children.length == 0) {
-				if (restoreable)
+				if (restoreable) {
 					try {
 						backupStore.backup(directory);
 					} catch (IOException e) {
 						return Util.createError(NLS.bind(Messages.backup_file_failed, directory));
 					}
-				else
+				} else {
 					directory.delete();
+				}
 			}
 		}
 

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CleanupzipAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CleanupzipAction.java
@@ -41,11 +41,13 @@ public class CleanupzipAction extends ProvisioningAction {
 
 	public static IStatus cleanupzip(Map<String, Object> parameters, boolean restoreable) {
 		String source = (String) parameters.get(ActionConstants.PARM_SOURCE);
-		if (source == null)
+		if (source == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_SOURCE, ACTION_CLEANUPZIP));
+		}
 		String target = (String) parameters.get(ActionConstants.PARM_TARGET);
-		if (target == null)
+		if (target == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_TARGET, ACTION_CLEANUPZIP));
+		}
 
 		IInstallableUnit iu = (IInstallableUnit) parameters.get(ActionConstants.PARM_IU);
 		Profile profile = (Profile) parameters.get(ActionConstants.PARM_PROFILE);
@@ -64,13 +66,15 @@ public class CleanupzipAction extends ProvisioningAction {
 						iuPropertyKey = key;
 						String storedTarget = key.substring(sourcePrefix.length());
 						unzipped = substituteTarget(storedTarget, target, iuProperties.get(key));
-					} else
+					} else {
 						return Status.OK_STATUS; // possible two unzips of this source - give up on best effort
+					}
 				}
 			}
 			// no match
-			if (unzipped == null)
+			if (unzipped == null) {
 				return Status.OK_STATUS;
+			}
 		}
 
 		IBackupStore store = restoreable ? (IBackupStore) parameters.get(NativeTouchpoint.PARM_BACKUP) : null;
@@ -79,32 +83,37 @@ public class CleanupzipAction extends ProvisioningAction {
 		while (tokenizer.hasMoreTokens()) {
 			String fileName = tokenizer.nextToken();
 			File file = new File(fileName);
-			if (!file.exists())
+			if (!file.exists()) {
 				continue;
+			}
 
-			if (file.isDirectory())
+			if (file.isDirectory()) {
 				directories.add(file);
-			else {
-				if (store != null)
+			} else {
+				if (store != null) {
 					try {
 						store.backup(file);
 					} catch (IOException e) {
 						return new Status(IStatus.ERROR, Activator.ID, IStatus.OK,
 								NLS.bind(Messages.backup_file_failed, file.getPath()), e);
 					}
-				else
+				} else {
 					file.delete();
+				}
 			}
 		}
 		// sort directories by path length longest path is in top
 		// this will make sure that a sub folder will be removed before its parent
 		directories.sort((f1, f2) -> {
-			if (f1 == f2)
+			if (f1 == f2) {
 				return 0;
-			if (f1 != null && f2 == null)
+			}
+			if (f1 != null && f2 == null) {
 				return -1;
-			if (f1 == null)
+			}
+			if (f1 == null) {
 				return 1;
+			}
 			try {
 				return Integer.valueOf(f2.getCanonicalPath().length()).compareTo(f1.getCanonicalPath().length());
 			} catch (IOException e) {
@@ -116,15 +125,17 @@ public class CleanupzipAction extends ProvisioningAction {
 			if (store != null) {
 				File[] children = directory.listFiles();
 				// Since backup will deny backup of non empty directory a check must be made
-				if (children == null || children.length == 0)
+				if (children == null || children.length == 0) {
 					try {
 						store.backupDirectory(directory);
 					} catch (IOException e) {
 						return new Status(IStatus.ERROR, Activator.ID, IStatus.OK,
 								NLS.bind(Messages.backup_file_failed, directory.getPath()), e);
 					}
-			} else
+				}
+			} else {
 				directory.delete();
+			}
 		}
 
 		profile.removeInstallableUnitProperty(iu, iuPropertyKey);
@@ -136,10 +147,12 @@ public class CleanupzipAction extends ProvisioningAction {
 		StringTokenizer tokenizer = new StringTokenizer(value, ActionConstants.PIPE);
 		while (tokenizer.hasMoreTokens()) {
 			String fileName = tokenizer.nextToken().trim();
-			if (fileName.length() == 0)
+			if (fileName.length() == 0) {
 				continue;
-			if (fileName.startsWith(oldTarget))
+			}
+			if (fileName.startsWith(oldTarget)) {
 				fileName = newTarget + fileName.substring(oldTarget.length());
+			}
 
 			buffer.append(fileName).append(ActionConstants.PIPE);
 		}

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CopyAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/CopyAction.java
@@ -51,14 +51,16 @@ public class CopyAction extends ProvisioningAction {
 		String target = (String) parameters.get(ActionConstants.PARM_COPY_TARGET);
 		IBackupStore backupStore = restoreable ? (IBackupStore) parameters.get(NativeTouchpoint.PARM_BACKUP) : null;
 
-		if (target == null)
+		if (target == null) {
 			return new Status(IStatus.ERROR, Activator.ID, IStatus.OK,
 					NLS.bind(Messages.param_not_set, ActionConstants.PARM_COPY_TARGET, ID), null);
+		}
 
 		String source = (String) parameters.get(ActionConstants.PARM_COPY_SOURCE);
-		if (source == null)
+		if (source == null) {
 			return new Status(IStatus.ERROR, Activator.ID, IStatus.OK,
 					NLS.bind(Messages.param_not_set, ActionConstants.PARM_COPY_SOURCE, ID), null);
+		}
 
 		String overwrite = (String) parameters.get(ActionConstants.PARM_COPY_OVERWRITE);
 		Profile profile = (Profile) parameters.get(ActionConstants.PARM_PROFILE);
@@ -121,34 +123,41 @@ public class CopyAction extends ProvisioningAction {
 	 */
 	private static void xcopy(ArrayList<File> copiedFiles, File source, File target, boolean overwrite,
 			IBackupStore backupStore) throws IOException {
-		if (!source.exists())
+		if (!source.exists()) {
 			throw new IOException("Source: " + source + " does not exists"); //$NON-NLS-1$//$NON-NLS-2$
+		}
 
 		if (source.isDirectory()) {
 			if (target.exists() && target.isFile()) {
-				if (!overwrite)
+				if (!overwrite) {
 					throw new IOException("Target: " + target + " already exists"); //$NON-NLS-1$//$NON-NLS-2$
-				if (backupStore != null)
+				}
+				if (backupStore != null) {
 					backupStore.backup(target);
-				else
+				} else {
 					target.delete();
+				}
 			}
-			if (!target.exists())
+			if (!target.exists()) {
 				target.mkdirs();
+			}
 			copiedFiles.add(target);
 			File[] children = source.listFiles();
-			if (children == null)
+			if (children == null) {
 				throw new IOException("Error while retrieving children of directory: " + source); //$NON-NLS-1$
+			}
 			for (File child : children) {
 				xcopy(copiedFiles, child, new File(target, child.getName()), overwrite, backupStore);
 			}
 			return;
 		}
-		if (target.exists() && !overwrite)
+		if (target.exists() && !overwrite) {
 			throw new IOException("Target: " + target + " already exists"); //$NON-NLS-1$//$NON-NLS-2$
+		}
 
-		if (!target.getParentFile().exists() && !target.getParentFile().mkdirs())
+		if (!target.getParentFile().exists() && !target.getParentFile().mkdirs()) {
 			throw new IOException("Target: Path " + target.getParent() + " could not be created"); //$NON-NLS-1$//$NON-NLS-2$
+		}
 
 		try {
 			Util.copyStream(new FileInputStream(source), true, new FileOutputStream(target), true);

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/LinkAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/LinkAction.java
@@ -27,16 +27,19 @@ public class LinkAction extends ProvisioningAction {
 	@Override
 	public IStatus execute(Map<String, Object> parameters) {
 		String targetDir = (String) parameters.get(ActionConstants.PARM_TARGET_DIR);
-		if (targetDir == null)
+		if (targetDir == null) {
 			return new Status(IStatus.ERROR, Activator.ID, IStatus.OK, NLS.bind(Messages.param_not_set, ActionConstants.PARM_TARGET_DIR, ID), null);
+		}
 
 		String linkTarget = (String) parameters.get(ActionConstants.PARM_LINK_TARGET);
-		if (linkTarget == null)
+		if (linkTarget == null) {
 			return new Status(IStatus.ERROR, Activator.ID, IStatus.OK, NLS.bind(Messages.param_not_set, ActionConstants.PARM_LINK_TARGET, ID), null);
+		}
 
 		String linkName = (String) parameters.get(ActionConstants.PARM_LINK_NAME);
-		if (linkName == null)
+		if (linkName == null) {
 			return new Status(IStatus.ERROR, Activator.ID, IStatus.OK, NLS.bind(Messages.param_not_set, ActionConstants.PARM_LINK_NAME, ID), null);
+		}
 
 		String force = (String) parameters.get(ActionConstants.PARM_LINK_FORCE);
 
@@ -52,8 +55,9 @@ public class LinkAction extends ProvisioningAction {
 
 	@Override
 	public IStatus undo(Map<String, Object> parameters) {
-		if (WINDOWS)
+		if (WINDOWS) {
 			return Status.OK_STATUS;
+		}
 		String targetDir = (String) parameters.get(ActionConstants.PARM_TARGET_DIR);
 		String linkName = (String) parameters.get(ActionConstants.PARM_LINK_NAME);
 
@@ -76,13 +80,15 @@ public class LinkAction extends ProvisioningAction {
 	 * @throws IOException if backup of existing file fails
 	 */
 	private void ln(String targetDir, String linkTarget, String linkName, boolean force, IBackupStore store) throws IOException {
-		if (WINDOWS)
+		if (WINDOWS) {
 			return;
+		}
 		// backup a file that would be overwritten using "force == true"
 		if (force && store != null) {
 			File xFile = new File(targetDir, linkName);
-			if (xFile.exists())
+			if (xFile.exists()) {
 				store.backup(xFile);
+			}
 		}
 		Runtime r = Runtime.getRuntime();
 		try {

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/MkdirAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/MkdirAction.java
@@ -28,13 +28,15 @@ public class MkdirAction extends ProvisioningAction {
 	@Override
 	public IStatus execute(Map<String, Object> parameters) {
 		String path = (String) parameters.get(ActionConstants.PARM_PATH);
-		if (path == null)
+		if (path == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_PATH, ID));
+		}
 		File dir = new File(path);
 		// A created or existing directory is ok
 		dir.mkdir();
-		if (dir.isDirectory())
+		if (dir.isDirectory()) {
 			return Status.OK_STATUS;
+		}
 		// mkdir could have failed because of permissions, or because of an existing file
 		return Util.createError(NLS.bind(Messages.mkdir_failed, path, ID));
 	}
@@ -42,13 +44,15 @@ public class MkdirAction extends ProvisioningAction {
 	@Override
 	public IStatus undo(Map<String, Object> parameters) {
 		String path = (String) parameters.get(ActionConstants.PARM_PATH);
-		if (path == null)
+		if (path == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_PATH, ID));
+		}
 		File dir = new File(path);
 		// although not perfect, it at least prevents a faulty mkdir to delete a file on undo
 		// worst case is that an empty directory could be deleted
-		if (dir.isDirectory())
+		if (dir.isDirectory()) {
 			dir.delete();
+		}
 		return Status.OK_STATUS;
 	}
 }

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/RemoveAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/RemoveAction.java
@@ -28,15 +28,18 @@ public class RemoveAction extends ProvisioningAction {
 	@Override
 	public IStatus execute(Map<String, Object> parameters) {
 		String path = (String) parameters.get(ActionConstants.PARM_PATH);
-		if (path == null)
+		if (path == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_PATH, ID));
+		}
 		File file = new File(path);
 		// ignore if the file is already removed
-		if (!file.exists())
+		if (!file.exists()) {
 			return Status.OK_STATUS;
+		}
 		IBackupStore store = (IBackupStore) parameters.get(NativeTouchpoint.PARM_BACKUP);
-		if (store == null)
+		if (store == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, NativeTouchpoint.PARM_BACKUP, ID));
+		}
 		try {
 			store.backupAll(file);
 		} catch (IOException e) {

--- a/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/RmdirAction.java
+++ b/bundles/org.eclipse.equinox.p2.touchpoint.natives/src/org/eclipse/equinox/internal/p2/touchpoint/natives/actions/RmdirAction.java
@@ -28,15 +28,17 @@ public class RmdirAction extends ProvisioningAction {
 	@Override
 	public IStatus execute(Map<String, Object> parameters) {
 		String path = (String) parameters.get(ActionConstants.PARM_PATH);
-		if (path == null)
+		if (path == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_PATH, ID));
+		}
 
 		IBackupStore store = (IBackupStore) parameters.get(NativeTouchpoint.PARM_BACKUP);
 
 		File dir = new File(path);
-		if (!dir.isDirectory())
+		if (!dir.isDirectory()) {
 			return Util.createError(NLS.bind(Messages.rmdir_failed, path, ID));
-		if (store != null)
+		}
+		if (store != null) {
 			try {
 				store.backupDirectory(dir);
 			} catch (IOException e) {
@@ -46,8 +48,9 @@ public class RmdirAction extends ProvisioningAction {
 				// Ignore the delete/backup if the directory was not empty as this preserves the
 				// the original semantics. See Bug 272312 for more detail.
 			}
-		else
+		} else {
 			dir.delete();
+		}
 		return Status.OK_STATUS;
 	}
 
@@ -55,11 +58,13 @@ public class RmdirAction extends ProvisioningAction {
 	public IStatus undo(Map<String, Object> parameters) {
 		String path = (String) parameters.get(ActionConstants.PARM_PATH);
 		IBackupStore store = (IBackupStore) parameters.get(NativeTouchpoint.PARM_BACKUP);
-		if (path == null)
+		if (path == null) {
 			return Util.createError(NLS.bind(Messages.param_not_set, ActionConstants.PARM_PATH, ID));
+		}
 		// only need to create a dir if backup was not used
-		if (store == null)
+		if (store == null) {
 			new File(path).mkdir();
+		}
 		return Status.OK_STATUS;
 	}
 }


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible

