### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.transport.ecf

### DIFF
--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileInfoReader.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/FileInfoReader.java
@@ -73,8 +73,7 @@ class FileInfoReader {
 					Exception e = event.getException();
 					if (e != null) {
 						exception.set(e);
-					} else if (event instanceof IRemoteFileSystemBrowseEvent) {
-						IRemoteFileSystemBrowseEvent fsbe = (IRemoteFileSystemBrowseEvent) event;
+					} else if (event instanceof IRemoteFileSystemBrowseEvent fsbe) {
 						IRemoteFile[] remoteFiles = fsbe.getRemoteFiles();
 						if (remoteFiles != null && remoteFiles.length > 0) {
 							remote.set(remoteFiles[0]);

--- a/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryStatusHelper.java
+++ b/bundles/org.eclipse.equinox.p2.transport.ecf/src/org/eclipse/equinox/internal/p2/transport/ecf/RepositoryStatusHelper.java
@@ -311,14 +311,12 @@ public abstract class RepositoryStatusHelper {
 	 * @throws FileNotFoundException if 't' represents a file not found
 	 */
 	public static void checkFileNotFound(Throwable t, URI toDownload) throws FileNotFoundException {
-		if (t instanceof IncomingFileTransferException) {
-			IncomingFileTransferException e = (IncomingFileTransferException) t;
+		if (t instanceof IncomingFileTransferException e) {
 			if (e.getErrorCode() == 404 || e.getErrorCode() == 403 || e.getErrorCode() == 300) {
 				throw new FileNotFoundException(toDownload.toString());
 			}
 		}
-		if (t instanceof BrowseFileTransferException) {
-			BrowseFileTransferException e = (BrowseFileTransferException) t;
+		if (t instanceof BrowseFileTransferException e) {
 			if (e.getErrorCode() == 404 || e.getErrorCode() == 403 || e.getErrorCode() == 300) {
 				throw new FileNotFoundException(toDownload.toString());
 			}


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

