### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.ui.discovery

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/repository/RepositoryDiscoveryStrategy.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/repository/RepositoryDiscoveryStrategy.java
@@ -85,8 +85,7 @@ public class RepositoryDiscoveryStrategy extends AbstractDiscoveryStrategy {
 				IInstallableUnit categoryIU = (IInstallableUnit) category.getData();
 				Collection<IRequirement> required = categoryIU.getRequirements();
 				for (IRequirement requirement : required) {
-					if (requirement instanceof IRequiredCapability) {
-						IRequiredCapability capability = (IRequiredCapability) requirement;
+					if (requirement instanceof IRequiredCapability capability) {
 						CatalogItem item = catalogItemById.get(capability.getName());
 						if (item != null) {
 							item.setCategoryId(category.getId());

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/WorkbenchUtil.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/util/WorkbenchUtil.java
@@ -107,8 +107,7 @@ public class WorkbenchUtil {
 		if (!isFiltering()) {
 			return true;
 		}
-		if (object instanceof IPluginContribution) {
-			IPluginContribution contribution = (IPluginContribution) object;
+		if (object instanceof IPluginContribution contribution) {
 			if (contribution.getPluginId() != null) {
 				IWorkbenchActivitySupport workbenchActivitySupport = PlatformUI.getWorkbench().getActivitySupport();
 				IIdentifier identifier = workbenchActivitySupport.getActivityManager().getIdentifier(createUnifiedId(contribution));

--- a/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/wizards/CatalogViewer.java
+++ b/bundles/org.eclipse.equinox.p2.ui.discovery/src/org/eclipse/equinox/internal/p2/ui/discovery/wizards/CatalogViewer.java
@@ -129,9 +129,8 @@ public class CatalogViewer extends FilteredViewer {
 		public boolean select(Viewer filteredViewer, Object parentElement, Object element) {
 			if (element instanceof CatalogItem) {
 				return doFilter((CatalogItem) element);
-			} else if (element instanceof CatalogCategory) {
+			} else if (element instanceof CatalogCategory category) {
 				// only show categories if at least one child is visible
-				CatalogCategory category = (CatalogCategory) element;
 				for (CatalogItem item : category.getItems()) {
 					if (doFilter(item)) {
 						return true;
@@ -164,8 +163,7 @@ public class CatalogViewer extends FilteredViewer {
 
 		@Override
 		protected boolean isLeafMatch(Viewer filteredViewer, Object element) {
-			if (element instanceof CatalogItem) {
-				CatalogItem descriptor = (CatalogItem) element;
+			if (element instanceof CatalogItem descriptor) {
 				if (!(filterMatches(descriptor.getName()) || filterMatches(descriptor.getDescription()) || filterMatches(descriptor.getProvider()) || filterMatches(descriptor.getLicense()))) {
 					return false;
 				}


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

