### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.ui.sdk.scheduler

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdater.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/AutomaticUpdater.java
@@ -70,8 +70,7 @@ public class AutomaticUpdater implements IUpdateListener {
 
 	private void createProfileListener() {
 		profileListener = o -> {
-			if (o instanceof IProfileEvent) {
-				IProfileEvent event = (IProfileEvent) o;
+			if (o instanceof IProfileEvent event) {
 				if (event.getReason() == IProfileEvent.CHANGED && sameProfile(event.getProfileId())) {
 					triggerNewUpdateNotification();
 				}

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/PreviousConfigurationFinder.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/PreviousConfigurationFinder.java
@@ -91,10 +91,9 @@ public class PreviousConfigurationFinder {
 
 		@Override
 		public boolean equals(Object other) {
-			if (!(other instanceof Identifier)) {
+			if (!(other instanceof Identifier o)) {
 				return false;
 			}
-			Identifier o = (Identifier) other;
 			if (major == o.major && minor == o.minor && service == o.service) {
 				return true;
 			}

--- a/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/migration/MigrationPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui.sdk.scheduler/src/org/eclipse/equinox/internal/p2/ui/sdk/scheduler/migration/MigrationPage.java
@@ -164,11 +164,9 @@ public class MigrationPage extends WizardPage implements ISelectableIUsPage, Lis
 			IInstallableUnit iu1 = ProvUI.getAdapter(e1, IInstallableUnit.class);
 			IInstallableUnit iu2 = ProvUI.getAdapter(e2, IInstallableUnit.class);
 			if (iu1 != null && iu2 != null) {
-				if (viewer1 instanceof TreeViewer) {
-					TreeViewer treeViewer = (TreeViewer) viewer1;
+				if (viewer1 instanceof TreeViewer treeViewer) {
 					IBaseLabelProvider baseLabel = treeViewer.getLabelProvider();
-					if (baseLabel instanceof ITableLabelProvider) {
-						ITableLabelProvider tableProvider = (ITableLabelProvider) baseLabel;
+					if (baseLabel instanceof ITableLabelProvider tableProvider) {
 						String e1p = tableProvider.getColumnText(e1, getSortColumn());
 						String e2p = tableProvider.getColumnText(e2, getSortColumn());
 						// don't suppress this warning as it will cause build-time warning
@@ -466,8 +464,7 @@ public class MigrationPage extends WizardPage implements ISelectableIUsPage, Lis
 		viewer.setInput(getInput());
 
 		viewer.getTree().addListener(SWT.Selection, event -> {
-			if (event.item instanceof TreeItem && event.detail == SWT.CHECK) {
-				TreeItem treeItem = (TreeItem) event.item;
+			if (event.item instanceof TreeItem treeItem && event.detail == SWT.CHECK) {
 				IInstallableUnit iu = ProvUI.getAdapter(event.item.getData(), IInstallableUnit.class);
 				if (treeItem.getChecked()) {
 					selectedUnitsToMigrate.add(iu);


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

