### PR TITLE
Clean Code for bundles/org.eclipse.equinox.p2.ui

### DIFF
--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvUIProvisioningListener.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/ProvUIProvisioningListener.java
@@ -51,9 +51,7 @@ public abstract class ProvUIProvisioningListener implements SynchronousProvision
 			if (Tracing.DEBUG_EVENTS_CLIENT) {
 				Tracing.debug("Batch Eventing:  Ignore Following Events. " + getReceiverString()); //$NON-NLS-1$
 			}
-		} else if (o instanceof RepositoryOperationEndingEvent) {
-			RepositoryOperationEndingEvent event = (RepositoryOperationEndingEvent) o;
-
+		} else if (o instanceof RepositoryOperationEndingEvent event) {
 			if (Tracing.DEBUG_EVENTS_CLIENT) {
 				Tracing.debug("Batch Eventing:  Batch Ended. " + getReceiverString()); //$NON-NLS-1$
 			}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/UpdateManagerCompatibility.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/UpdateManagerCompatibility.java
@@ -165,8 +165,7 @@ public class UpdateManagerCompatibility {
 	}
 
 	private static void writeObject(String indent, Object obj, PrintWriter writer) {
-		if (obj instanceof MetadataRepositoryElement) {
-			MetadataRepositoryElement element = (MetadataRepositoryElement) obj;
+		if (obj instanceof MetadataRepositoryElement element) {
 			String sel = element.isEnabled() ? "true" : "false"; //$NON-NLS-1$ //$NON-NLS-2$
 			String name = element.getName();
 			writer.print(indent + "<site url=\"" + URIUtil.toUnencodedString(element.getLocation()) + "\" selected=\"" + sel + "\" name=\"" + getWritableXMLString(name) + "\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/ExistingIUInProfileAction.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/actions/ExistingIUInProfileAction.java
@@ -47,8 +47,7 @@ public abstract class ExistingIUInProfileAction extends ProfileModificationActio
 		IProfile profile = getProfile();
 		if (selectionArray.length > 0) {
 			for (Object selection : selectionArray) {
-				if (selection instanceof InstalledIUElement) {
-					InstalledIUElement element = (InstalledIUElement) selection;
+				if (selection instanceof InstalledIUElement element) {
 					// If the parents are different, then they are either from
 					// different profiles or are nested in different parts of the tree.
 					// Either way, this makes the selection invalid.

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ContainerCheckedTreeViewer.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/ContainerCheckedTreeViewer.java
@@ -111,8 +111,7 @@ public class ContainerCheckedTreeViewer extends CheckboxTreeViewer {
 	 */
 	protected void doCheckStateChanged(Object element) {
 		Widget item = findItem(element);
-		if (item instanceof TreeItem) {
-			TreeItem treeItem = (TreeItem) item;
+		if (item instanceof TreeItem treeItem) {
 			treeItem.setGrayed(false);
 			// BEGIN MODIFICATION OF COPIED CLASS
 			if (element instanceof QueriedElement && treeItem.getChecked()) {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/InstalledIUGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/InstalledIUGroup.java
@@ -99,9 +99,8 @@ public class InstalledIUGroup extends StructuredIUGroup {
 			public Object[] getChildren(Object element) {
 				Object[] objects = elementChildren.get(element);
 				if (objects == null) {
-					if (element instanceof InstalledIUElement) {
+					if (element instanceof InstalledIUElement installedIUElement) {
 						// Special case handling.
-						InstalledIUElement installedIUElement = (InstalledIUElement) element;
 						if (!installedIUElement.shouldShowChildren()) {
 							// If the element shouldn't show children because that would create a cycle,
 							// don't show any.
@@ -134,13 +133,11 @@ public class InstalledIUGroup extends StructuredIUGroup {
 
 					// If there are children and this is an InstalledIUElement, cache the mapping
 					// from the IU to the child IUs for reuse above.
-					if (objects.length != 0 && element instanceof InstalledIUElement) {
-						InstalledIUElement installedIUElement = (InstalledIUElement) element;
+					if (objects.length != 0 && element instanceof InstalledIUElement installedIUElement) {
 						IInstallableUnit iu = installedIUElement.getIU();
 						Set<IInstallableUnit> children = new LinkedHashSet<>();
 						for (Object object : objects) {
-							if (object instanceof InstalledIUElement) {
-								InstalledIUElement childInstalledIUElement = (InstalledIUElement) object;
+							if (object instanceof InstalledIUElement childInstalledIUElement) {
 								IInstallableUnit childIU = childInstalledIUElement.getIU();
 								children.add(childIU);
 							} else {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RemediationGroup.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/RemediationGroup.java
@@ -83,8 +83,7 @@ public class RemediationGroup {
 
 		@Override
 		public Object[] getChildren(Object parentElement) {
-			if (parentElement instanceof RemedyElementCategory) {
-				RemedyElementCategory category = (RemedyElementCategory) parentElement;
+			if (parentElement instanceof RemedyElementCategory category) {
 				return category.getElements().toArray();
 			}
 			return null;
@@ -231,8 +230,7 @@ public class RemediationGroup {
 				if (element instanceof RemedyElementCategory) {
 					return ((RemedyElementCategory) element).getName();
 				}
-				if (element instanceof RemedyIUDetail) {
-					RemedyIUDetail iu = (RemedyIUDetail) element;
+				if (element instanceof RemedyIUDetail iu) {
 					String label = iu.getIu().getProperty(IInstallableUnit.PROP_NAME, null);
 					if (label == null) {
 						label = iu.getIu().getId();
@@ -244,8 +242,7 @@ public class RemediationGroup {
 
 			@Override
 			public Image getImage(Object element) {
-				if (element instanceof RemedyElementCategory) {
-					RemedyElementCategory category = (RemedyElementCategory) element;
+				if (element instanceof RemedyElementCategory category) {
 					if (category.getName().equals(ProvUIMessages.RemedyCategoryAdded)) {
 						return ProvUIImages.getImage(ProvUIImages.IMG_ADDED);
 					}
@@ -258,8 +255,7 @@ public class RemediationGroup {
 					if (category.getName().equals(ProvUIMessages.RemedyCategoryRemoved)) {
 						return ProvUIImages.getImage(ProvUIImages.IMG_REMOVED);
 					}
-				} else if (element instanceof RemedyIUDetail) {
-					RemedyIUDetail iuDetail = (RemedyIUDetail) element;
+				} else if (element instanceof RemedyIUDetail iuDetail) {
 					int status = compare(iuDetail);
 					if (compare(iuDetail.getBeingInstalledVersion(), iuDetail.getRequestedVersion()) < 0 && containerPage != null && containerPage.getWizard() instanceof UpdateWizard) {
 						Image img = ProvUIImages.getImage(ProvUIImages.IMG_UPGRADED_IU);
@@ -286,8 +282,7 @@ public class RemediationGroup {
 
 			@Override
 			public String getToolTipText(Object element) {
-				if (element instanceof RemedyIUDetail) {
-					RemedyIUDetail iuDetail = (RemedyIUDetail) element;
+				if (element instanceof RemedyIUDetail iuDetail) {
 					String toolTipText = ""; //$NON-NLS-1$
 					List<String> versions = new ArrayList<>();
 					if (iuDetail.getInstalledVersion() != null) {
@@ -334,8 +329,7 @@ public class RemediationGroup {
 		versionColumn.setLabelProvider(new ColumnLabelProvider() {
 			@Override
 			public String getText(Object element) {
-				if (element instanceof RemedyIUDetail) {
-					RemedyIUDetail iu = (RemedyIUDetail) element;
+				if (element instanceof RemedyIUDetail iu) {
 					if (iu.getBeingInstalledVersion() != null) {
 						return iu.getBeingInstalledVersion().toString();
 					}
@@ -351,8 +345,7 @@ public class RemediationGroup {
 		idColumn.setLabelProvider(new ColumnLabelProvider() {
 			@Override
 			public String getText(Object element) {
-				if (element instanceof RemedyIUDetail) {
-					RemedyIUDetail iu = (RemedyIUDetail) element;
+				if (element instanceof RemedyIUDetail iu) {
 					return iu.getIu().getId();
 				}
 				return ""; //$NON-NLS-1$
@@ -467,8 +460,7 @@ public class RemediationGroup {
 			IInstallableUnit iu1 = ((RemedyIUDetail) e1).getIu();
 			IInstallableUnit iu2 = ((RemedyIUDetail) e2).getIu();
 			if (iu1 != null && iu2 != null) {
-				if (viewer1 instanceof TreeViewer) {
-					TreeViewer theTreeViewer = (TreeViewer) viewer1;
+				if (viewer1 instanceof TreeViewer theTreeViewer) {
 					ColumnLabelProvider labelProvider = (ColumnLabelProvider) theTreeViewer.getLabelProvider(sortColumn);
 					String e1p = labelProvider.getText(e1);
 					String e2p = labelProvider.getText(e2);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/SelectableIUsPage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/SelectableIUsPage.java
@@ -247,8 +247,7 @@ public class SelectableIUsPage extends ResolutionStatusPage implements IResoluti
 		ArrayList<Object> selections = new ArrayList<>(initialSelections.length);
 
 		for (Object initialSelection : initialSelections) {
-			if (initialSelection instanceof AvailableUpdateElement) {
-				AvailableUpdateElement element = (AvailableUpdateElement) initialSelection;
+			if (initialSelection instanceof AvailableUpdateElement element) {
 				if (element.isLockedForUpdate()) {
 					continue;
 				}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustCertificateDialog.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/TrustCertificateDialog.java
@@ -427,8 +427,7 @@ public class TrustCertificateDialog extends SelectionDialog {
 			public String getText(Object element) {
 				if (element instanceof TreeNode) {
 					Object o = ((TreeNode) element).getValue();
-					if (o instanceof PGPPublicKey) {
-						PGPPublicKey key = (PGPPublicKey) o;
+					if (o instanceof PGPPublicKey key) {
 						String userFriendlyFingerPrint = userFriendlyFingerPrint(key);
 						java.util.List<String> users = new ArrayList<>();
 						key.getUserIDs().forEachRemaining(users::add);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/UpdateWizard.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/dialogs/UpdateWizard.java
@@ -135,14 +135,12 @@ public class UpdateWizard extends WizardWithLicenses {
 			ArrayList<AvailableUpdateElement> list = new ArrayList<>(selectedElements.length);
 			ArrayList<AvailableUpdateElement> selected = new ArrayList<>(selectedElements.length);
 			for (Object selectedElement : selectedElements) {
-				if (selectedElement instanceof AvailableUpdateElement) {
-					AvailableUpdateElement element = (AvailableUpdateElement) selectedElement;
+				if (selectedElement instanceof AvailableUpdateElement element) {
 					AvailableUpdateElement newElement = new AvailableUpdateElement(root, element.getIU(),
 							element.getIUToBeUpdated(), getProfileId(), shouldShowProvisioningPlanChildren());
 					list.add(newElement);
 					selected.add(newElement);
-				} else if (selectedElement instanceof Update) {
-					Update update = (Update) selectedElement;
+				} else if (selectedElement instanceof Update update) {
 					AvailableUpdateElement newElement = new AvailableUpdateElement(root, update.replacement,
 							update.toUpdate, getProfileId(), shouldShowProvisioningPlanChildren());
 					list.add(newElement);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/QueriedElementWrapper.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/model/QueriedElementWrapper.java
@@ -49,8 +49,7 @@ public abstract class QueriedElementWrapper extends ElementWrapper {
 	 */
 	@Override
 	protected Object wrap(Object item) {
-		if (item instanceof QueriedElement) {
-			QueriedElement element = (QueriedElement) item;
+		if (item instanceof QueriedElement element) {
 			if (!element.knowsQueryable()) {
 				element.setQueryable(queryable);
 			}
@@ -69,15 +68,13 @@ public abstract class QueriedElementWrapper extends ElementWrapper {
 			// All we can do is look for the most common reasons and guess.  If the collection
 			// is empty and the parent is an IU, then being empty is not a big deal, it means
 			// we are in drilldown.
-			if (parent instanceof MetadataRepositoryElement) {
-				MetadataRepositoryElement repo = (MetadataRepositoryElement) parent;
+			if (parent instanceof MetadataRepositoryElement repo) {
 				RepositoryTracker manipulator = repo.getProvisioningUI().getRepositoryTracker();
 				if (manipulator.hasNotFoundStatusBeenReported(repo.getLocation())) {
 					return emptyExplanation(IStatus.ERROR, NLS.bind(ProvUIMessages.QueriedElementWrapper_SiteNotFound, URIUtil.toUnencodedString(repo.getLocation())), ""); //$NON-NLS-1$
 				}
 			}
-			if (parent instanceof QueriedElement) {
-				QueriedElement element = (QueriedElement) parent;
+			if (parent instanceof QueriedElement element) {
 				IUViewQueryContext context = element.getQueryContext();
 				if (context == null) {
 					context = ProvUI.getQueryContext(element.getPolicy());

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/AvailableIUWrapper.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/AvailableIUWrapper.java
@@ -121,8 +121,7 @@ public class AvailableIUWrapper extends QueriedElementWrapper {
 			isPatch = iuInformation.isPatch;
 		}
 		// subclass already made this an element, just set the install flag
-		if (item instanceof AvailableIUElement) {
-			AvailableIUElement element = (AvailableIUElement) item;
+		if (item instanceof AvailableIUElement element) {
 			element.setIsInstalled(isInstalled);
 			element.setIsUpdate(isUpdate);
 			element.setIsPatch(isPatch);
@@ -139,8 +138,7 @@ public class AvailableIUWrapper extends QueriedElementWrapper {
 		}
 
 		IIUElement element = makeDefaultElement(iu);
-		if (element instanceof AvailableIUElement) {
-			AvailableIUElement availableElement = (AvailableIUElement) element;
+		if (element instanceof AvailableIUElement availableElement) {
 			availableElement.setIsInstalled(isInstalled);
 			availableElement.setIsUpdate(isUpdate);
 			availableElement.setIsPatch(isPatch);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/CategoryElementWrapper.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/CategoryElementWrapper.java
@@ -40,8 +40,7 @@ public class CategoryElementWrapper extends QueriedElementWrapper {
 
 	@Override
 	protected boolean shouldWrap(Object match) {
-		if (match instanceof IInstallableUnit) {
-			IInstallableUnit iu = (IInstallableUnit) match;
+		if (match instanceof IInstallableUnit iu) {
 			Collection<IRequirement> requirements = iu.getRequirements();
 			for (IRequirement requirement : requirements) {
 				if (requirement instanceof IRequiredCapability) {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/MetadataRepositoryElementWrapper.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/query/MetadataRepositoryElementWrapper.java
@@ -56,8 +56,7 @@ public class MetadataRepositoryElementWrapper extends QueriedElementWrapper {
 		// Assume the item is enabled
 
 		// if the parent is a queried element then use its provisioning UI to find out about enablement
-		if (parent instanceof QueriedElement) {
-			QueriedElement qe = (QueriedElement) parent;
+		if (parent instanceof QueriedElement qe) {
 			ProvisioningUI provisioningUI = qe.getProvisioningUI();
 			ProvisioningSession session = provisioningUI.getSession();
 			boolean enabled = ProvUI.getMetadataRepositoryManager(session).isEnabled((URI) item);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/CertificateLabelProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/CertificateLabelProvider.java
@@ -36,8 +36,7 @@ public class CertificateLabelProvider implements ILabelProvider {
 	public String getText(Object element) {
 		if (element instanceof TreeNode) {
 			Object o = ((TreeNode) element).getValue();
-			if (o instanceof X509Certificate) {
-				X509Certificate cert = (X509Certificate) o;
+			if (o instanceof X509Certificate cert) {
 				return getText(cert);
 			}
 		}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/DeferredQueryContentProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/DeferredQueryContentProvider.java
@@ -112,8 +112,7 @@ public class DeferredQueryContentProvider extends ProvElementContentProvider {
 
 	@Override
 	public Object[] getChildren(final Object parent) {
-		if (parent instanceof RemoteQueriedElement) {
-			RemoteQueriedElement element = (RemoteQueriedElement) parent;
+		if (parent instanceof RemoteQueriedElement element) {
 			// We rely on the assumption that the queryable is the most expensive
 			// thing to get vs. the query itself being expensive.
 			// (loading a repo vs. querying a repo afterward)

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/DeferredQueryTreeContentManager.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/DeferredQueryTreeContentManager.java
@@ -100,8 +100,7 @@ public class DeferredQueryTreeContentManager extends DeferredTreeContentManager 
 
 	@Override
 	protected void runClearPlaceholderJob(final PendingUpdateAdapter placeholder) {
-		if (placeholder instanceof ElementPendingUpdateAdapter) {
-			ElementPendingUpdateAdapter pendingUpdate = (ElementPendingUpdateAdapter) placeholder;
+		if (placeholder instanceof ElementPendingUpdateAdapter pendingUpdate) {
 			if (pendingUpdate.isRemoved()) {
 				return;
 			}

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUDragAdapter.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/IUDragAdapter.java
@@ -105,11 +105,9 @@ public class IUDragAdapter extends DragSourceAdapter {
 		List<IInstallableUnit> ius = new ArrayList<>();
 
 		ISelection selection = selectionProvider.getSelection();
-		if (!(selection instanceof IStructuredSelection) || selection.isEmpty()) {
+		if (!(selection instanceof IStructuredSelection structuredSelection) || selection.isEmpty()) {
 			return null;
 		}
-		IStructuredSelection structuredSelection = (IStructuredSelection) selection;
-
 		Iterator<?> iter = structuredSelection.iterator();
 		while (iter.hasNext()) {
 			IInstallableUnit iu = ProvUI.getAdapter(iter.next(), IInstallableUnit.class);

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/ProvElementLabelProvider.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/internal/p2/ui/viewers/ProvElementLabelProvider.java
@@ -53,8 +53,7 @@ public class ProvElementLabelProvider extends LabelProvider implements ITableLab
 			}
 			return ((IProfile) obj).getProfileId();
 		}
-		if (obj instanceof IInstallableUnit) {
-			IInstallableUnit iu = (IInstallableUnit) obj;
+		if (obj instanceof IInstallableUnit iu) {
 			return iu.getId();
 		}
 		if (obj instanceof IRepository<?>) {
@@ -71,12 +70,10 @@ public class ProvElementLabelProvider extends LabelProvider implements ITableLab
 			}
 			return URIUtil.toUnencodedString(((IRepositoryElement<?>) obj).getLocation());
 		}
-		if (obj instanceof IArtifactKey) {
-			IArtifactKey key = (IArtifactKey) obj;
+		if (obj instanceof IArtifactKey key) {
 			return key.getId() + " [" + key.getClassifier() + "]"; //$NON-NLS-1$//$NON-NLS-2$
 		}
-		if (obj instanceof IProcessingStepDescriptor) {
-			IProcessingStepDescriptor descriptor = (IProcessingStepDescriptor) obj;
+		if (obj instanceof IProcessingStepDescriptor descriptor) {
 			return descriptor.getProcessorId();
 		}
 		if (obj instanceof IRequiredCapability) {
@@ -153,8 +150,7 @@ public class ProvElementLabelProvider extends LabelProvider implements ITableLab
 				if (element instanceof IRepositoryElement<?>) {
 					return URIUtil.toUnencodedString(((IRepositoryElement<?>) element).getLocation());
 				}
-				if (element instanceof IArtifactKey) {
-					IArtifactKey key = (IArtifactKey) element;
+				if (element instanceof IArtifactKey key) {
 					return key.getVersion().toString();
 				}
 				if (element instanceof IRequiredCapability) {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/InstalledSoftwarePage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/InstalledSoftwarePage.java
@@ -350,8 +350,7 @@ public class InstalledSoftwarePage extends InstallationPage implements ICopyable
 				return true;
 			}
 
-			if (element instanceof InstalledIUElement) {
-				InstalledIUElement data = (InstalledIUElement) element;
+			if (element instanceof InstalledIUElement data) {
 				IInstallableUnit iu = data.getIU();
 				boolean match = false;
 				if (iu != null) {

--- a/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RevertProfilePage.java
+++ b/bundles/org.eclipse.equinox.p2.ui/src/org/eclipse/equinox/p2/ui/RevertProfilePage.java
@@ -102,8 +102,7 @@ public class RevertProfilePage extends InstallationPage implements ICopyable {
 
 		@Override
 		protected void setValue(Object element, Object value) {
-			if (element instanceof RollbackProfileElement && value instanceof String) {
-				RollbackProfileElement ele = ((RollbackProfileElement) element);
+			if (element instanceof RollbackProfileElement ele && value instanceof String) {
 				ele.setProfileTag((String) value);
 				// save
 				IProfileRegistry registry = ProvUI.getProfileRegistry(ui.getSession());
@@ -490,9 +489,8 @@ public class RevertProfilePage extends InstallationPage implements ICopyable {
 				Object selected = iter.next();
 				// If it is a recognized element and it is not the current profile, then it can
 				// be deleted.
-				if (selected instanceof RollbackProfileElement
+				if (selected instanceof RollbackProfileElement snapshot
 						&& !((RollbackProfileElement) selected).isCurrentProfile()) {
-					RollbackProfileElement snapshot = (RollbackProfileElement) selected;
 					IProfileRegistry registry = ProvUI.getProfileRegistry(getSession());
 					if (registry != null) {
 						try {


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

